### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) Vulnerability in Scrapers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - [XML External Entity (XXE) Prevention]
+**Vulnerability:** Found `xml.etree.ElementTree` being used to parse external untrusted RSS feeds in scrapers (`theverge.py` and `producthunt.py`). This standard library is vulnerable to XML vulnerabilities such as XXE and Billion Laughs.
+**Learning:** External feeds must always be treated as untrusted data. Standard XML parsers often do not protect against recursive entities or external entity resolution.
+**Prevention:** Always use `defusedxml.ElementTree` instead of the standard library `xml.etree.ElementTree` when parsing untrusted XML/RSS feeds to prevent XML-based attacks.

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -7,3 +7,4 @@ beautifulsoup4==4.*
 feedparser==6.*
 openai==1.*
 tzdata
+defusedxml==0.7.*

--- a/functions/scrapers/producthunt.py
+++ b/functions/scrapers/producthunt.py
@@ -6,7 +6,7 @@ Fetches trending products from Product Hunt RSS feed.
 import httpx
 from typing import List, Dict, Any
 from datetime import datetime
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from bs4 import BeautifulSoup
 
 

--- a/functions/scrapers/theverge.py
+++ b/functions/scrapers/theverge.py
@@ -6,7 +6,7 @@ Fetches latest tech news from The Verge using their RSS feed.
 import httpx
 from typing import List, Dict, Any
 from datetime import datetime
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 try:
     from ..resilience import retry_with_backoff


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `xml.etree.ElementTree` to parse untrusted RSS feeds from The Verge and Product Hunt, which is vulnerable to XML External Entity (XXE) and Billion Laughs attacks.
🎯 Impact: Attackers could potentially read local files, execute server-side request forgery (SSRF), or cause a denial of service (DoS) by injecting malicious entities into the XML payload.
🔧 Fix: Replaced `xml.etree.ElementTree` with the safe `defusedxml.ElementTree` equivalent and added `defusedxml` to dependencies.
✅ Verification: Tested the affected scrapers (`test_scrapers.py`, `test_new_scrapers.py`) and verified they successfully parsed their respective RSS feeds with no functionality regressions.

---
*PR created automatically by Jules for task [17107035021142529554](https://jules.google.com/task/17107035021142529554) started by @AminSS99*