### PR TITLE
feat: add /export command to download saved articles

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -670,6 +670,61 @@ async def save_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(t('article_exists', user_lang))
 
 
+async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /export command - export saved articles as Markdown file."""
+    from .user_storage import get_saved_articles, get_user_language
+    from .translations import t
+    import io
+
+    telegram_id = update.effective_user.id
+    user_lang = get_user_language(telegram_id)
+    articles = get_saved_articles(telegram_id, limit=500)
+
+    if not articles:
+        await update.message.reply_text(t('export_empty', user_lang), parse_mode='Markdown')
+        return
+
+    cat_emoji = {
+        'ai': '🤖', 'security': '🔒', 'crypto': '💰', 'startups': '🚀',
+        'hardware': '💻', 'software': '📱', 'tech': '🔧'
+    }
+
+    # Build markdown content
+    md_lines = [f"# Saved Articles ({len(articles)})\n"]
+    for i, article in enumerate(articles, 1):
+        title = article.get('title', 'Untitled')
+        url = article.get('url', '')
+        source = article.get('source', '')
+        category = article.get('category', 'tech')
+        saved_at = article.get('saved_at', '')
+
+        emoji = cat_emoji.get(category, '🔧')
+        date_str = saved_at[:10] if saved_at else ''
+
+        md_lines.append(f"## {i}. {emoji} {title}")
+        if url:
+            md_lines.append(f"**URL:** {url}")
+        if source:
+            md_lines.append(f"**Source:** {source}")
+        if category:
+            md_lines.append(f"**Category:** {category}")
+        if date_str:
+            md_lines.append(f"**Date:** {date_str}")
+        md_lines.append("")  # Empty line
+
+    md_content = "\n".join(md_lines)
+
+    # Create in-memory file
+    file_bytes = io.BytesIO(md_content.encode('utf-8'))
+    file_bytes.name = "saved_articles.md"
+
+    await update.message.reply_document(
+        document=file_bytes,
+        caption=t('export_caption', user_lang),
+        parse_mode='Markdown'
+    )
+
+
 async def clear_saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle /clear_saved command."""
     from .user_storage import clear_saved_articles, get_user_language
@@ -1603,6 +1658,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("start", "Start the bot"),
         BotCommand("news", "Get AI news digest"),
         BotCommand("saved", "View saved articles"),
+        BotCommand("export", "Export saved articles"),
         BotCommand("search", "Search articles"),
         BotCommand("semsearch", "Semantic search saved"),
         BotCommand("filter", "Filter saved by category"),
@@ -1625,6 +1681,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("start", "Запустить бота"),
         BotCommand("news", "Получить дайджест новостей"),
         BotCommand("saved", "Сохранённые статьи"),
+        BotCommand("export", "Экспорт сохранённых статей"),
         BotCommand("search", "Поиск статей"),
         BotCommand("semsearch", "Умный поиск"),
         BotCommand("filter", "Фильтр по категориям"),
@@ -1691,6 +1748,7 @@ def create_bot_application() -> Application:
     # New feature commands
     application.add_handler(CommandHandler("saved", saved_command))
     application.add_handler(CommandHandler("save", save_command))
+    application.add_handler(CommandHandler("export", export_command))
     application.add_handler(CommandHandler("clear_saved", clear_saved_command))
     application.add_handler(CommandHandler("clear", clear_saved_command))  # Alias for /clear_saved
     application.add_handler(CommandHandler("search", search_command))

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -117,6 +117,8 @@ Use /sources to toggle sources""",
         'recap_empty': "📊 **Weekly Recap**\n\nNo articles saved this week. Start saving articles to see your recap!",
         'article_deleted': "🗑️ Article deleted!",
         'article_saved_single': "✅ Article saved! Category: {category}",
+        'export_empty': "📭 **No saved articles!**\n\nYou haven't saved any articles yet.",
+        'export_caption': "📁 **Your Saved Articles**\n\nHere is the export of your saved articles.",
         
         # Category labels
         'cat_ai': "🤖 AI",
@@ -250,6 +252,8 @@ _Работает локально - настройки сохранятся п�
         'recap_empty': "📊 **Недельный обзор**\n\nНет сохранённых статей за неделю. Начните сохранять!",
         'article_deleted': "🗑️ Статья удалена!",
         'article_saved_single': "✅ Статья сохранена! Категория: {category}",
+        'export_empty': "📭 **Нет сохранённых статей!**\n\nВы ещё не сохранили ни одной статьи.",
+        'export_caption': "📁 **Ваши сохранённые статьи**\n\nВот экспорт ваших сохранённых статей.",
         
         # Category labels
         'cat_ai': "🤖 ИИ",


### PR DESCRIPTION
**Feature Description**
Adds a new `/export` command that allows users to download all their saved articles as a clean Markdown file (`.md`). 

**Why it matters**
This feature solves the data portability problem. Currently, users can save articles to read later or filter them by category, but there's no easy way to get that data out of the bot if they want to store it in Notion, Obsidian, or just keep a local copy. It's a high-impact, low-effort feature that users will appreciate for data ownership.

**Changes made:**
1. Added `export_command` to `functions/telegram_bot.py`. It fetches up to 500 saved articles for the user and writes them to an in-memory `io.BytesIO` buffer formatted as a Markdown document.
2. Sent the buffer as a document back to the user via `update.message.reply_document()`.
3. Added the `/export` command to the bot's application handlers and registered it in the native Telegram menu for both English (`commands_en`) and Russian (`commands_ru`).
4. Added new localization strings `export_empty` and `export_caption` to `functions/translations.py` for both 'en' and 'ru' languages.

---
*PR created automatically by Jules for task [11144451355791293194](https://jules.google.com/task/11144451355791293194) started by @AminSS99*