### PR TITLE
🛡️ Sentinel: [HIGH] Fix XXE vulnerability in RSS scrapers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Prevent XML External Entity (XXE) and Billion Laughs Vulnerabilities
+**Vulnerability:** Untrusted XML/RSS feeds were parsed using the standard library `xml.etree.ElementTree`, which is vulnerable to XXE (XML External Entity) and Billion Laughs attacks.
+**Learning:** The project's scrapers fetch external RSS/Atom feeds and parse them directly. The standard Python XML parsers do not restrict external entities by default, leading to potential denial of service or information disclosure.
+**Prevention:** Always use `defusedxml.ElementTree` instead of `xml.etree.ElementTree` when parsing untrusted XML data to mitigate these risks. Ensure the `defusedxml` package is included in `functions/requirements.txt`.

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -7,3 +7,4 @@ beautifulsoup4==4.*
 feedparser==6.*
 openai==1.*
 tzdata
+defusedxml==0.*

--- a/functions/scrapers/producthunt.py
+++ b/functions/scrapers/producthunt.py
@@ -6,7 +6,9 @@ Fetches trending products from Product Hunt RSS feed.
 import httpx
 from typing import List, Dict, Any
 from datetime import datetime
-import xml.etree.ElementTree as ET
+# Using defusedxml to prevent XXE (XML External Entity) and Billion Laughs vulnerabilities
+import defusedxml.ElementTree as ET
+from xml.etree.ElementTree import ParseError
 from bs4 import BeautifulSoup
 
 
@@ -114,8 +116,13 @@ def fetch_producthunt(limit: int = 10) -> List[Dict[str, Any]]:
                 for entry in entries[:limit]:
                     title = entry.find('atom:title', atom_ns)
                     link = entry.find('atom:link', atom_ns)
-                    summary = entry.find('atom:summary', atom_ns) or entry.find('atom:content', atom_ns)
-                    published = entry.find('atom:published', atom_ns) or entry.find('atom:updated', atom_ns)
+                    summary = entry.find('atom:summary', atom_ns)
+                    if summary is None:
+                        summary = entry.find('atom:content', atom_ns)
+
+                    published = entry.find('atom:published', atom_ns)
+                    if published is None:
+                        published = entry.find('atom:updated', atom_ns)
 
                     if title is None or link is None:
                         continue
@@ -140,7 +147,7 @@ def fetch_producthunt(limit: int = 10) -> List[Dict[str, Any]]:
             print(f"Product Hunt: Fetched {len(products)} products")
             return products
             
-    except ET.ParseError as e:
+    except ParseError as e:
         print(f"Product Hunt XML parse error: {e}")
         return []
     except Exception as e:

--- a/functions/scrapers/theverge.py
+++ b/functions/scrapers/theverge.py
@@ -6,7 +6,8 @@ Fetches latest tech news from The Verge using their RSS feed.
 import httpx
 from typing import List, Dict, Any
 from datetime import datetime
-import xml.etree.ElementTree as ET
+# Using defusedxml to prevent XXE (XML External Entity) and Billion Laughs vulnerabilities
+import defusedxml.ElementTree as ET
 
 try:
     from ..resilience import retry_with_backoff


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The standard library `xml.etree.ElementTree` parser was being used to parse untrusted external RSS/Atom feeds in both The Verge and Product Hunt scrapers. This parser is known to be vulnerable to XML External Entity (XXE) and Billion Laughs attacks since it does not disable external entity resolution by default.
🎯 **Impact:** If an attacker were to manipulate the external feed or DNS responses to serve malicious XML, they could potentially execute a Denial of Service (Billion Laughs) or trigger Server-Side Request Forgery/information disclosure (XXE) on the server environment hosting the bot.
🔧 **Fix:** Replaced the vulnerable `xml.etree.ElementTree` module with `defusedxml.ElementTree`, which is a safe, drop-in replacement that explicitly disables external entity resolution. Added `defusedxml` to `functions/requirements.txt`. Additionally, resolved a related deprecation warning regarding truth value testing of Element objects during test execution. A Sentinel journal entry has been created to document this learning pattern for the repository.
✅ **Verification:** Verified by running `pytest test_scrapers.py test_new_scrapers.py` with `PYTHONPATH=$PWD/functions` set to ensure the scrapers successfully parse feeds using the new library without errors.

---
*PR created automatically by Jules for task [6194816865219495779](https://jules.google.com/task/6194816865219495779) started by @AminSS99*