### PR TITLE
feat: Add `/export` command to download saved articles

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -681,6 +681,46 @@ async def clear_saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE
     await update.message.reply_text(t('cleared_saved', user_lang))
 
 
+async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /export command - export saved articles as CSV."""
+    from .user_storage import get_all_saved_articles, get_user_language
+    from .translations import t
+    import csv
+    import io
+
+    telegram_id = update.effective_user.id
+    user_lang = get_user_language(telegram_id)
+    articles = get_all_saved_articles(telegram_id)
+
+    if not articles:
+        await update.message.reply_text(t('no_saved', user_lang), parse_mode='Markdown')
+        return
+
+    # Create CSV in memory
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['Title', 'URL', 'Source', 'Category', 'Saved At'])
+
+    for article in articles:
+        writer.writerow([
+            article.get('title', 'Untitled'),
+            article.get('url', ''),
+            article.get('source', ''),
+            article.get('category', ''),
+            article.get('saved_at', '')
+        ])
+
+    # Convert to BytesIO for sending
+    csv_bytes = io.BytesIO(output.getvalue().encode('utf-8'))
+    csv_bytes.name = 'saved_articles.csv'
+
+    await update.message.reply_document(
+        document=csv_bytes,
+        filename='saved_articles.csv',
+        caption=t('export_caption', user_lang)
+    )
+
+
 async def filter_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle /filter command - filter saved articles by category."""
     from .user_storage import get_saved_articles, get_user_language
@@ -1607,6 +1647,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("semsearch", "Semantic search saved"),
         BotCommand("filter", "Filter saved by category"),
         BotCommand("recap", "Weekly saved articles recap"),
+        BotCommand("export", "Export saved articles"),
         BotCommand("status", "View your settings"),
         BotCommand("language", "Change language"),
         BotCommand("sources", "Toggle news sources"),
@@ -1629,6 +1670,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("semsearch", "Умный поиск"),
         BotCommand("filter", "Фильтр по категориям"),
         BotCommand("recap", "Еженедельная сводка"),
+        BotCommand("export", "Экспорт статей"),
         BotCommand("status", "Настройки"),
         BotCommand("language", "Язык"),
         BotCommand("sources", "Источники новостей"),
@@ -1697,6 +1739,7 @@ def create_bot_application() -> Application:
     application.add_handler(CommandHandler("language", language_command))
     application.add_handler(CommandHandler("filter", filter_command))
     application.add_handler(CommandHandler("recap", recap_command))
+    application.add_handler(CommandHandler("export", export_command))
     application.add_handler(CommandHandler("share", share_command))
     application.add_handler(CommandHandler("trends", trends_command))
     application.add_handler(CommandHandler("timezone", timezone_command))

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -57,6 +57,7 @@ Use /settime to change it!""",
 • /saved - View all saved articles
 • /filter <category> - Filter by category (ai, security, crypto, startups, hardware, software, tech)
 • /recap - Weekly recap of saved articles
+• /export - Export saved articles to CSV
 • /clear_saved - Clear all saved articles
 
 ⚙️ **Settings**
@@ -115,6 +116,7 @@ Use /sources to toggle sources""",
         'filter_empty': "📂 No articles in category **{category}**.\n\nSave some articles first!",
         'recap_header': "📊 **Weekly Recap**\n_Your top saved articles this week:_\n\n",
         'recap_empty': "📊 **Weekly Recap**\n\nNo articles saved this week. Start saving articles to see your recap!",
+        'export_caption': "📁 **Your Saved Articles Export**\n\nHere is your full list of saved articles in CSV format.",
         'article_deleted': "🗑️ Article deleted!",
         'article_saved_single': "✅ Article saved! Category: {category}",
         
@@ -190,6 +192,7 @@ Use /sources to toggle sources""",
 • /saved - Просмотреть все сохранённые
 • /filter <категория> - Фильтр по категории (ai, security, crypto, startups, hardware, software, tech)
 • /recap - Недельный обзор сохранённых
+• /export - Экспорт сохранённых статей (CSV)
 • /clear_saved - Очистить все сохранённые
 
 ⚙️ **Настройки**
@@ -248,6 +251,7 @@ _Работает локально - настройки сохранятся п�
         'filter_empty': "📂 Нет статей в категории **{category}**.\n\nСначала сохраните статьи!",
         'recap_header': "📊 **Недельный обзор**\n_Ваши топ статьи за эту неделю:_\n\n",
         'recap_empty': "📊 **Недельный обзор**\n\nНет сохранённых статей за неделю. Начните сохранять!",
+        'export_caption': "📁 **Экспорт сохранённых статей**\n\nВот полный список ваших сохранённых статей в формате CSV.",
         'article_deleted': "🗑️ Статья удалена!",
         'article_saved_single': "✅ Статья сохранена! Категория: {category}",
         

--- a/functions/user_storage.py
+++ b/functions/user_storage.py
@@ -187,6 +187,30 @@ def get_saved_articles(telegram_id: int, limit: int = 10, category: str = None) 
     return list(reversed(articles[-limit:]))
 
 
+def get_all_saved_articles(telegram_id: int) -> List[Dict[str, Any]]:
+    """Get all of a user's saved articles from Firestore (or local) without limit."""
+    db = get_firestore_client()
+    if db:
+        try:
+            from google.cloud import firestore
+
+            query = db.collection('users').document(str(telegram_id)).collection('saved_articles')
+
+            # Order by saved_at desc
+            docs = query.order_by('saved_at', direction=firestore.Query.DESCENDING).stream()
+
+            return [doc.to_dict() for doc in docs]
+        except Exception as e:
+            print(f"Firestore get all error: {e}")
+            # Fall through
+
+    # Fallback to local
+    data = _load_local_data(telegram_id)
+    articles = data.get('saved_articles', [])
+
+    return list(reversed(articles))
+
+
 def delete_saved_article(telegram_id: int, url: str) -> bool:
     """Delete a saved article by URL."""
     db = get_firestore_client()


### PR DESCRIPTION
This pull request introduces a new feature that allows users to easily export all of their saved articles into a CSV file. This fulfills the requirement for a meaningful, small feature improvement that uses existing architecture and components.

### Changes:
- `functions/user_storage.py`: Added `get_all_saved_articles` function to retrieve a user's entire collection of saved articles from Firestore (or local fallback).
- `functions/telegram_bot.py`: Created the `export_command` handler which processes the user's saved articles, formats them as CSV data entirely in memory (using `io.StringIO` and `io.BytesIO`), and sends it back to the user via Telegram's document sharing API. Registered `/export` in bot commands.
- `functions/translations.py`: Updated to include English and Russian translations for the export feature and updated the `/help` menu to include the new command.

The feature is lightweight, does not require new external dependencies, safely handles data in-memory (no disk IO in Cloud Functions), and scopes access correctly to only the requesting user.

---
*PR created automatically by Jules for task [4650999246718938069](https://jules.google.com/task/4650999246718938069) started by @AminSS99*