### PR TITLE
feat: Add Product Hunt as a news source

### DIFF
--- a/functions/database.py
+++ b/functions/database.py
@@ -98,7 +98,7 @@ def create_or_update_user(
             'username': username,
             'schedule_time': resolved_schedule,
             'timezone': resolved_timezone,
-            'sources': ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github'],
+            'sources': ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github', 'producthunt'],
             'created_at': datetime.utcnow(),
             'updated_at': datetime.utcnow(),
             'is_active': resolved_active

--- a/functions/main.py
+++ b/functions/main.py
@@ -165,6 +165,7 @@ async def process_scheduled_digest(target_time: str = None) -> dict:
     from .scrapers.ai_blogs import fetch_ai_blogs
     from .scrapers.theverge import fetch_theverge
     from .scrapers.github_trending import fetch_github_trending
+    from .scrapers.producthunt import fetch_producthunt
     from .summarizer import summarize_news
     
     if target_time:
@@ -191,6 +192,7 @@ async def process_scheduled_digest(target_time: str = None) -> dict:
     tasks.append(fetch_ai_blogs(3))
     tasks.append(asyncio.to_thread(fetch_theverge, 5))
     tasks.append(asyncio.to_thread(fetch_github_trending, 5))
+    tasks.append(asyncio.to_thread(fetch_producthunt, 8))
     
     results = await asyncio.gather(*tasks, return_exceptions=True)
     
@@ -362,6 +364,7 @@ def fetch_news(request: Request):
     from .scrapers.ai_blogs import fetch_ai_blogs
     from .scrapers.theverge import fetch_theverge
     from .scrapers.github_trending import fetch_github_trending
+    from .scrapers.producthunt import fetch_producthunt
     from .summarizer import summarize_news
     
     try:
@@ -385,6 +388,9 @@ def fetch_news(request: Request):
             
             if 'all' in sources_arg or 'github' in sources_arg:
                 tasks.append(asyncio.to_thread(fetch_github_trending, 5))
+
+            if 'all' in sources_arg or 'producthunt' in sources_arg:
+                tasks.append(asyncio.to_thread(fetch_producthunt, 5))
                 
             results = await asyncio.gather(*tasks, return_exceptions=True)
             

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -134,7 +134,7 @@ async def news_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_lang = get_user_language(telegram_id)
 
     # Resolve sources first so cache is language+source scoped.
-    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github']
+    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github', 'producthunt']
     try:
         from .database import get_user
         user = get_user(telegram_id)
@@ -218,6 +218,7 @@ async def news_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         from .scrapers.ai_blogs import fetch_ai_blogs
         from .scrapers.theverge import fetch_theverge
         from .scrapers.github_trending import fetch_github_trending
+        from .scrapers.producthunt import fetch_producthunt
         from .summarizer import summarize_news
         
         # Source list already resolved above (used in cache key as well).
@@ -235,6 +236,8 @@ async def news_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             tasks.append(asyncio.to_thread(fetch_theverge, 8))
         if 'github' in sources:
             tasks.append(asyncio.to_thread(fetch_github_trending, 8))
+        if 'producthunt' in sources:
+            tasks.append(asyncio.to_thread(fetch_producthunt, 8))
             
         results = await asyncio.gather(*tasks, return_exceptions=True)
         
@@ -431,7 +434,7 @@ async def sources_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_lang = get_user_language(telegram_id)
     
     # Try to get user preferences from database, use defaults if not available
-    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github']  # Default all enabled
+    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github', 'producthunt']  # Default all enabled
     try:
         from .database import get_user, create_or_update_user
         user = get_user(telegram_id)
@@ -462,6 +465,10 @@ async def sources_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         [InlineKeyboardButton(
             f"{'✅' if 'github' in sources else '❌'} GitHub Trending",
             callback_data='toggle_github'
+        )],
+        [InlineKeyboardButton(
+            f"{'✅' if 'producthunt' in sources else '❌'} Product Hunt",
+            callback_data='toggle_producthunt'
         )],
     ]
     reply_markup = InlineKeyboardMarkup(keyboard)
@@ -511,6 +518,10 @@ async def toggle_source_callback(update: Update, context: ContextTypes.DEFAULT_T
             f"{'✅' if 'github' in new_sources else '❌'} GitHub Trending",
             callback_data='toggle_github'
         )],
+        [InlineKeyboardButton(
+            f"{'✅' if 'producthunt' in new_sources else '❌'} Product Hunt",
+            callback_data='toggle_producthunt'
+        )],
     ]
     reply_markup = InlineKeyboardMarkup(keyboard)
     
@@ -549,6 +560,7 @@ async def status_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         'ai_blogs': 'AI Blogs',
         'theverge': 'The Verge',
         'github': 'GitHub Trending',
+        'producthunt': 'Product Hunt',
     }
     
     sources_text = '\n'.join([f"  вЂў {source_names.get(s, s)}" for s in sources])
@@ -1331,7 +1343,7 @@ async def refresh_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
     # Resolve enabled sources for scoped cache invalidation.
-    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github']
+    sources = ['hackernews', 'techcrunch', 'ai_blogs', 'theverge', 'github', 'producthunt']
     try:
         from .database import get_user
         user = get_user(telegram_id)
@@ -1364,6 +1376,7 @@ async def refresh_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
         from .scrapers.ai_blogs import fetch_ai_blogs
         from .scrapers.theverge import fetch_theverge
         from .scrapers.github_trending import fetch_github_trending
+        from .scrapers.producthunt import fetch_producthunt
         from .summarizer import summarize_news
         tasks = []
         if 'hackernews' in sources:
@@ -1376,6 +1389,8 @@ async def refresh_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             tasks.append(asyncio.to_thread(fetch_theverge, 10))
         if 'github' in sources:
             tasks.append(asyncio.to_thread(fetch_github_trending, 10))
+        if 'producthunt' in sources:
+            tasks.append(asyncio.to_thread(fetch_producthunt, 10))
         results = await asyncio.gather(*tasks, return_exceptions=True)
         all_news = []
         for res in results:


### PR DESCRIPTION
This PR adds Product Hunt as an active news source to the LensAI bot. \n\nThe scraper (`functions/scrapers/producthunt.py`) was already available in the repository but was disconnected. This change wires it up to the existing architecture so users can now receive trending product news.\n\nChanges included:\n- Added `fetch_producthunt` to the Telegram bot (`news_command`, `refresh_callback`).\n- Updated `sources_command` and `status_command` UI to include a toggle for Product Hunt.\n- Enabled `fetch_producthunt` inside `process_scheduled_digest` and `fetch_news` in `main.py`.\n- Updated `create_or_update_user` database defaults to include `producthunt`.

---
*PR created automatically by Jules for task [1261102774542882929](https://jules.google.com/task/1261102774542882929) started by @AminSS99*