### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak hashing algorithms (MD5/SHA-1)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-11 - Enforce Cryptographically Secure Hashing
+**Vulnerability:** Weak hashing algorithms (MD5 and SHA-1) were used for cache keys, article hashes, and unique identifiers.
+**Learning:** The application codebase mistakenly relied on legacy algorithms instead of using the secure, deterministic SHA-256 implementation established in `functions.security_utils.stable_hash`. Even when generating short identifiers (like 8-character hashes for Telegram callbacks), modern hashes should be truncated rather than using outdated fast-hashing functions.
+**Prevention:** Always use `stable_hash` from `functions.security_utils` for hashing requirements. Avoid `hashlib.md5` and `hashlib.sha1` completely across the application.

--- a/functions/cache.py
+++ b/functions/cache.py
@@ -4,7 +4,7 @@ Firestore-based cache with TTL for news digests.
 """
 
 import time
-import hashlib
+from .security_utils import stable_hash
 from typing import Any, Optional, List
 from datetime import datetime, timezone
 try:
@@ -36,7 +36,8 @@ def build_digest_cache_key(language: str = "en", sources: Optional[List[str]] = 
     """
     normalized_sources = ",".join(sorted((sources or [])))
     payload = f"{scope}|{language}|{normalized_sources}"
-    suffix = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+    # Security: Use SHA-256 (via stable_hash) instead of weak SHA-1/MD5 to prevent collision attacks
+    suffix = stable_hash(payload)[:16]
     return f"news_digest_{suffix}"
 
 

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -166,8 +166,9 @@ async def news_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         header = t('cached_news', user_lang, timestamp=timestamp_str)
         
         # Generate digest ID for buttons
-        import hashlib
-        digest_id = hashlib.md5(cached_digest[:100].encode()).hexdigest()[:8]
+        from .security_utils import stable_hash
+        # Security: Replaced weak MD5 with deterministic SHA-256 (stable_hash)
+        digest_id = stable_hash(cached_digest[:100])[:8]
         reply_markup = get_digest_reply_markup(digest_id, user_lang)
         
         try:
@@ -271,8 +272,8 @@ async def news_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         set_cached_digest(digest, ttl_minutes=15, cache_key=cache_key)
         
         # Generate unique digest ID for rating tracking
-        import hashlib
-        digest_id = hashlib.md5(digest[:100].encode()).hexdigest()[:8]
+        from .security_utils import stable_hash
+        digest_id = stable_hash(digest[:100])[:8]
         
         # Store full digest + metadata for callback actions and personalization.
         try:
@@ -579,7 +580,7 @@ async def saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle /saved command - show saved articles with delete buttons."""
     from .user_storage import get_saved_articles, get_user_language
     from .translations import t
-    import hashlib
+    from .security_utils import stable_hash
     
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
@@ -626,7 +627,8 @@ async def saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         message += "\n"
         
         # Create delete button - use URL hash for unique ID
-        url_hash = hashlib.md5(url.encode()).hexdigest()[:8]
+        # Security: Replaced weak MD5 with deterministic SHA-256 (stable_hash)
+        url_hash = stable_hash(url)[:8]
         delete_label = "🗑️"
         keyboard.append([InlineKeyboardButton(f"{delete_label} {i}. {title[:25]}...", callback_data=f"del_{url_hash}")])
     
@@ -1092,11 +1094,11 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     url_hash = data.replace('del_', '')
     
     # Find the article with matching hash
-    import hashlib
+    from .security_utils import stable_hash
     articles = get_saved_articles(telegram_id, limit=50)
     
     for article in articles:
-        article_hash = hashlib.md5(article.get('url', '').encode()).hexdigest()[:8]
+        article_hash = stable_hash(article.get('url', ''))[:8]
         if article_hash == url_hash:
             delete_saved_article(telegram_id, article.get('url', ''))
             await query.edit_message_text(
@@ -1407,8 +1409,8 @@ async def refresh_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             'seen_hashes': list(new_seen)
         })
         digest = await summarize_news(items_to_summarize, language=user_lang)
-        import hashlib
-        digest_id = hashlib.md5(digest[:100].encode()).hexdigest()[:8]
+        from .security_utils import stable_hash
+        digest_id = stable_hash(digest[:100])[:8]
         # Persist callback context.
         save_temp_digest(digest_id, telegram_id, digest, articles_meta=items_to_summarize, ttl_hours=24)
         record_digest_context(digest_id, telegram_id, items_to_summarize)
@@ -1789,13 +1791,14 @@ async def send_digest_to_user(telegram_id: int, digest: str, articles_meta: list
     from telegram import Bot
     from .user_storage import get_user_language, save_temp_digest
     from .personalization import record_digest_context
-    import hashlib
+    from .security_utils import stable_hash
+
     
     bot = Bot(token=get_bot_token())
     user_lang = get_user_language(telegram_id)
     
     # Generate digest ID for buttons
-    digest_id = hashlib.md5(digest[:100].encode()).hexdigest()[:8]
+    digest_id = stable_hash(digest[:100])[:8]
     
     # Persist temp digest context so callbacks work for scheduled sends too.
     try:

--- a/functions/user_storage.py
+++ b/functions/user_storage.py
@@ -516,10 +516,11 @@ def update_refresh_session(telegram_id: int, updates: Dict[str, Any]):
 
 def get_article_hash(item: Dict[str, Any]) -> str:
     """Generate a consistent hash for an article item."""
-    import hashlib
+    from .security_utils import stable_hash
     # Use URL if available, otherwise title
     key = item.get('url', item.get('title', ''))
-    return hashlib.md5(key.encode('utf-8')).hexdigest()
+    # Security: Use SHA-256 (stable_hash) instead of vulnerable MD5
+    return stable_hash(key)
 
 
 # ============ TEMP DIGEST STORAGE ============


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was using cryptographically weak and outdated hashing algorithms (`hashlib.md5` and `hashlib.sha1`) to generate unique IDs, cache keys, and hashes.
🎯 **Impact:** While not used for password storage or digital signatures, utilizing MD5/SHA-1 is generally considered poor security practice. Weak hashing implementations can flag static analysis tools and establish an insecure baseline in the codebase, potentially leading to accidental misuse in sensitive contexts later.
🔧 **Fix:** 
- Replaced all instances of `hashlib.md5` and `hashlib.sha1` with the project-standard `stable_hash` from `functions.security_utils` (which uses SHA-256).
- Maintained the truncation behavior (`[:8]` and `[:16]`) to respect existing constraints like Telegram's 64-byte `callback_data` limit.
- Added inline comments highlighting the security reasoning.
- Logged the learning in the `.jules/sentinel.md` journal.
✅ **Verification:** Verified changes locally. Ensured functionality tests (`test_scrapers.py`, `test_new_scrapers.py`) still pass and checked for any regression issues in the imports.

---
*PR created automatically by Jules for task [7863000185093767881](https://jules.google.com/task/7863000185093767881) started by @AminSS99*