### PR TITLE
feat: Add inline URL summarize button

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1553,6 +1553,89 @@ async def why_digest_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
         err = f"Could not generate analysis: {str(e)[:80]}"
         await query.message.reply_text(err)
 
+async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Summarize a saved URL."""
+    from .user_storage import get_user_language, get_temp_url
+    from .translations import t
+    from .summarizer import get_async_client
+    import httpx
+    from bs4 import BeautifulSoup
+
+    query = update.callback_query
+    telegram_id = update.effective_user.id
+    user_lang = get_user_language(telegram_id)
+
+    parts = query.data.split('_')
+    if len(parts) < 3:
+        await query.answer("Invalid request", show_alert=True)
+        return
+
+    url_hash = parts[2]
+    url = get_temp_url(url_hash, telegram_id)
+
+    if not url:
+        await query.answer("Link expired. Please send the link again.", show_alert=True)
+        return
+
+    await query.answer(t('summarizing_link', user_lang))
+
+    try:
+        # Fetch content
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+
+        # Parse content safely
+        soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
+        paragraphs = soup.find_all('p')
+        text_content = "\n\n".join([p.get_text(strip=True) for p in paragraphs if len(p.get_text(strip=True)) > 20])
+
+        if not text_content:
+            text_content = soup.get_text(strip=True)
+
+        # Limit content size to avoid token limit
+        text_content = text_content[:5000]
+
+        if len(text_content) < 100:
+            await query.message.reply_text("Could not extract enough text to summarize.")
+            return
+
+        # Prepare prompt
+        if user_lang == 'ru':
+            system_prompt = "Сделай краткое содержание этой статьи в 3 пунктах и добавь 1 главный вывод. Отвечай на русском языке."
+        else:
+            system_prompt = "Summarize this article in 3 bullet points and 1 actionable takeaway. Respond in English."
+
+        user_prompt = f"Article:\n\n{text_content}"
+
+        # Call AI
+        ai_client = get_async_client()
+        response = await asyncio.wait_for(
+            ai_client.chat.completions.create(
+                model='deepseek-chat',
+                messages=[
+                    {'role': 'system', 'content': system_prompt},
+                    {'role': 'user', 'content': user_prompt},
+                ],
+                temperature=0.3,
+                max_tokens=400,
+            ),
+            timeout=25.0,
+        )
+
+        answer = response.choices[0].message.content
+
+        # Send back summary
+        try:
+            await query.message.reply_text(answer, parse_mode='Markdown', disable_web_page_preview=True)
+        except Exception:
+            await query.message.reply_text(answer, disable_web_page_preview=True)
+
+    except Exception as e:
+        error_msg = str(e)[:80]
+        await query.message.reply_text(t('summary_error', user_lang, error=error_msg))
+
+
 # ============ Q&A HANDLER ============
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1579,11 +1662,22 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     
     # Check if it's a URL to save
     if user_message.startswith('http://') or user_message.startswith('https://'):
-        from .user_storage import save_article
-        if save_article(telegram_id, user_message[:50], user_message):
-            await update.message.reply_text(t('link_saved', user_lang))
+        from .user_storage import save_article, save_temp_url
+        from .security_utils import stable_hash
+
+        is_saved = save_article(telegram_id, user_message[:50], user_message)
+
+        url_hash = stable_hash(user_message)[:8]
+        save_temp_url(url_hash, telegram_id, user_message)
+
+        reply_markup = InlineKeyboardMarkup([
+            [InlineKeyboardButton(t('btn_summarize', user_lang), callback_data=f"summarize_url_{url_hash}")]
+        ])
+
+        if is_saved:
+            await update.message.reply_text(t('link_saved', user_lang), reply_markup=reply_markup)
         else:
-            await update.message.reply_text(t('link_exists', user_lang))
+            await update.message.reply_text(t('link_exists', user_lang), reply_markup=reply_markup)
         return
     
     # Otherwise, treat as a question for AI
@@ -1774,6 +1868,7 @@ def create_bot_application() -> Application:
     application.add_handler(CallbackQueryHandler(save_digest_callback, pattern='^save_digest_'))
     application.add_handler(CallbackQueryHandler(why_digest_callback, pattern='^why_digest_'))
     application.add_handler(CallbackQueryHandler(delete_article_callback, pattern='^del_'))
+    application.add_handler(CallbackQueryHandler(summarize_url_callback, pattern='^summarize_url_'))
     
     # Add message handler for buttons and Q&A (handles any text that isn't a command)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -120,6 +120,9 @@ Use /sources to toggle sources""",
         'recap_empty': "📊 **Weekly Recap**\n\nNo articles saved this week. Start saving articles to see your recap!",
         'article_deleted': "🗑️ Article deleted!",
         'article_saved_single': "✅ Article saved! Category: {category}",
+        'btn_summarize': "🧠 Summarize",
+        'summarizing_link': "🔄 Analyzing article...",
+        'summary_error': "❌ Could not summarize article: {error}",
         
         # Category labels
         'cat_ai': "🤖 AI",
@@ -256,6 +259,9 @@ _Работает локально - настройки сохранятся п�
         'recap_empty': "📊 **Недельный обзор**\n\nНет сохранённых статей за неделю. Начните сохранять!",
         'article_deleted': "🗑️ Статья удалена!",
         'article_saved_single': "✅ Статья сохранена! Категория: {category}",
+        'btn_summarize': "🧠 Краткое содержание",
+        'summarizing_link': "🔄 Анализирую статью...",
+        'summary_error': "❌ Не удалось суммаризировать статью: {error}",
         
         # Category labels
         'cat_ai': "🤖 ИИ",

--- a/functions/user_storage.py
+++ b/functions/user_storage.py
@@ -524,6 +524,80 @@ def get_article_hash(item: Dict[str, Any]) -> str:
 
 # ============ TEMP DIGEST STORAGE ============
 
+def save_temp_url(
+    url_hash: str,
+    telegram_id: int,
+    url: str,
+    ttl_hours: int = 24
+) -> bool:
+    """
+    Store a URL temporarily for callback actions like summarize.
+    """
+    db = get_firestore_client()
+    if not db:
+        # Fallback to local
+        data = _load_local_data(telegram_id)
+        if 'urls_temp' not in data:
+            data['urls_temp'] = {}
+
+        data['urls_temp'][url_hash] = {
+            'url': url,
+            'expires_at': time.time() + (ttl_hours * 3600)
+        }
+
+        # Cleanup expired ones locally
+        current_time = time.time()
+        expired_keys = [k for k, v in data['urls_temp'].items() if v.get('expires_at', 0) < current_time]
+        for k in expired_keys:
+            del data['urls_temp'][k]
+
+        _save_local_data(telegram_id, data)
+        return True
+
+    try:
+        from google.cloud import firestore
+        expires_at = datetime.now(timezone.utc).timestamp() + (ttl_hours * 3600)
+        db.collection('urls_temp').document(url_hash).set({
+            'url': url,
+            'user_id': telegram_id,
+            'created_at': firestore.SERVER_TIMESTAMP,
+            'expires_at': expires_at
+        }, merge=True)
+        return True
+    except Exception as e:
+        print(f"Temp URL store error: {e}")
+        return False
+
+
+def get_temp_url(url_hash: str, telegram_id: Optional[int] = None) -> Optional[str]:
+    """Fetch stored temporary URL."""
+    db = get_firestore_client()
+    if not db:
+        if not telegram_id:
+            return None
+        # Fallback to local
+        data = _load_local_data(telegram_id)
+        temp_data = data.get('urls_temp', {}).get(url_hash)
+        if not temp_data:
+            return None
+        if time.time() > temp_data.get('expires_at', 0):
+            return None
+        return temp_data.get('url')
+
+    try:
+        doc = db.collection('urls_temp').document(url_hash).get()
+        if not doc.exists:
+            return None
+        data = doc.to_dict()
+        expires_at = data.get('expires_at')
+        if isinstance(expires_at, (int, float)) and time.time() > expires_at:
+            return None
+        return data.get('url')
+    except Exception as e:
+        print(f"Temp URL read error: {e}")
+        return None
+
+
 def save_temp_digest(
     digest_id: str,
     telegram_id: int,


### PR DESCRIPTION
This feature adds a small but impactful quality-of-life improvement. When a user sends a link to the bot to be saved, it now automatically replies with an inline button `[🧠 Summarize]`. 

Clicking the button extracts the actual web page content (using `httpx` and `BeautifulSoup`) and asks DeepSeek to provide a 3-bullet summary with an actionable takeaway. This significantly enhances the bot's usefulness as a "read-it-later" AI assistant. The implementation properly works around Telegram's 64-byte callback limit by utilizing a temporary Firestore cache for the URLs.

---
*PR created automatically by Jules for task [10278645407215849136](https://jules.google.com/task/10278645407215849136) started by @AminSS99*