### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix XML ParseError handling and DeprecationWarnings

### DIFF
--- a/functions/scrapers/producthunt.py
+++ b/functions/scrapers/producthunt.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Any
 from datetime import datetime
 from defusedxml import ElementTree as ET
 from defusedxml.common import DefusedXmlException
+from xml.etree.ElementTree import ParseError
 from bs4 import BeautifulSoup
 
 
@@ -115,8 +116,13 @@ def fetch_producthunt(limit: int = 10) -> List[Dict[str, Any]]:
                 for entry in entries[:limit]:
                     title = entry.find('atom:title', atom_ns)
                     link = entry.find('atom:link', atom_ns)
-                    summary = entry.find('atom:summary', atom_ns) or entry.find('atom:content', atom_ns)
-                    published = entry.find('atom:published', atom_ns) or entry.find('atom:updated', atom_ns)
+                    summary = entry.find('atom:summary', atom_ns)
+                    if summary is None:
+                        summary = entry.find('atom:content', atom_ns)
+
+                    published = entry.find('atom:published', atom_ns)
+                    if published is None:
+                        published = entry.find('atom:updated', atom_ns)
 
                     if title is None or link is None:
                         continue
@@ -141,7 +147,7 @@ def fetch_producthunt(limit: int = 10) -> List[Dict[str, Any]]:
             print(f"Product Hunt: Fetched {len(products)} products")
             return products
             
-    except (ET.ParseError, DefusedXmlException) as e:
+    except (ParseError, DefusedXmlException) as e:
         print(f"Product Hunt XML parse error: {e}")
         return []
     except Exception as e:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `defusedxml.ElementTree` module does not export a `ParseError` class. Trying to catch `ET.ParseError` from it would crash the exception handler if triggered. Additionally, truth value testing of `Element` objects is deprecated in Python 3.12+ and can lead to bugs where empty tags are evaluated as False.
🎯 Impact: Unhandled exceptions during parsing could crash the scraper tasks, preventing users from getting updates and opening up denial-of-service risks.
🔧 Fix: Imported `ParseError` explicitly from `xml.etree.ElementTree` and replaced deprecated truth value testing on XML elements with explicit `is None` checks.
✅ Verification: Ran `pytest test_scrapers.py test_new_scrapers.py` and `py_compile` on the modified files to ensure successful compilation and test passes.

---
*PR created automatically by Jules for task [10575495283082578116](https://jules.google.com/task/10575495283082578116) started by @AminSS99*