### PR TITLE
feat: Summarize saved articles directly from the /saved list

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -684,12 +684,15 @@ async def _render_saved_page(update_or_query, telegram_id: int, user_lang: str, 
             message += f" `{date_str}`"
         message += "\n"
         
-        # Create delete button - use URL hash for unique ID
+        # Create summarize and delete buttons - use URL hash for unique ID
         from .security_utils import stable_hash
         url_hash = stable_hash(url)[:8]
         delete_label = "🗑️"
         # encode page in callback data so delete button can refresh the correct page
-        keyboard.append([InlineKeyboardButton(f"{delete_label} {item_num}. {title[:25]}...", callback_data=f"del_{url_hash}_{page}")])
+        keyboard.append([
+            InlineKeyboardButton("🧠", callback_data=f"summarize_url_{url_hash}"),
+            InlineKeyboardButton(f"{delete_label} {item_num}. {title[:25]}...", callback_data=f"del_{url_hash}_{page}")
+        ])
     
     message += t('saved_footer', user_lang)
 
@@ -1745,7 +1748,7 @@ async def why_digest_callback(update: Update, context: ContextTypes.DEFAULT_TYPE
 
 async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Summarize a saved URL."""
-    from .user_storage import get_user_language, get_temp_url
+    from .user_storage import get_user_language, get_temp_url, get_saved_article_by_hash
     from .translations import t
     from .summarizer import chat_completion
     import httpx
@@ -1762,6 +1765,9 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
 
     url_hash = parts[2]
     url = get_temp_url(url_hash, telegram_id)
+
+    if not url:
+        url = get_saved_article_by_hash(telegram_id, url_hash)
 
     if not url:
         await query.answer("Link expired. Please send the link again.", show_alert=True)

--- a/functions/user_storage.py
+++ b/functions/user_storage.py
@@ -224,6 +224,17 @@ def get_saved_articles(telegram_id: int, limit: int = 10, category: str = None, 
     return rev_articles[offset:offset + limit]
 
 
+def get_saved_article_by_hash(telegram_id: int, url_hash: str) -> Optional[str]:
+    """Get a saved article URL by its stable hash."""
+    from .security_utils import stable_hash
+    articles = get_all_saved_articles(telegram_id)
+    for article in articles:
+        url = article.get('url', '')
+        if url and stable_hash(url)[:8] == url_hash:
+            return url
+    return None
+
+
 def get_all_saved_articles(telegram_id: int, category: str = None) -> List[Dict[str, Any]]:
     """Get all saved articles for a user from Firestore (or local)."""
     db = get_firestore_client()


### PR DESCRIPTION
This PR introduces a small but highly impactful UX improvement: users can now trigger the AI summarization feature on any article directly from their `/saved` list. 

Previously, users could only summarize an article immediately upon saving it via direct URL pasting. Now, they can save articles for later and summarize them on demand.

Changes:
1. Updated `_render_saved_page` to append a `🧠` (Summarize) button next to the `🗑️` (Delete) button for each article.
2. Updated `summarize_url_callback` to fallback to searching the user's saved articles list using the provided hash if the URL isn't found in the temporary (`urls_temp`) 24-hour cache.
3. Implemented `get_saved_article_by_hash` in `user_storage.py` to facilitate retrieving the full URL from the stable hash.

---
*PR created automatically by Jules for task [16332015402580033747](https://jules.google.com/task/16332015402580033747) started by @AminSS99*