### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in summarize_url_callback

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** MD5 and SHA-1 algorithms were being used for cryptographic hashes (e.g. `hashlib.md5` and `hashlib.sha1`) in several modules (`functions/cache.py`, `functions/telegram_bot.py`, `functions/user_storage.py`).
 **Learning:** Usage of insecure algorithms like MD5 and SHA1 poses a security risk due to known vulnerabilities and collision weaknesses. Even when used for non-critical identifiers, it is a bad practice and violates security policies.
 **Prevention:** Establish and strictly enforce a coding standard that mandates the use of modern, secure hash functions (such as SHA-256) for all hashing purposes. Here, we implemented a centralized `stable_hash` utility (using SHA-256) to ensure consistent and secure hashing across the codebase.
+
+## 2024-05-31 - [CRITICAL] Prevent Server-Side Request Forgery (SSRF) in link summarization
+**Vulnerability:** The `summarize_url_callback` functionality in `functions/telegram_bot.py` was directly fetching user-provided URLs using `httpx.AsyncClient` with `follow_redirects=True`. This allowed malicious actors to potentially fetch internal services or local files on the server (e.g., bypassing network controls or accessing metadata endpoints) by supplying a URL that resolved to an internal IP address or by supplying an external URL that redirected to an internal IP address.
+**Learning:** Even seemingly harmless functionalities like a "summarize this link" bot feature can be abused for SSRF if user-provided URLs are not strictly validated before fetching. The native HTTP client redirect following mechanisms are dangerous because the validation is only applied to the initial URL, not the subsequent redirects.
+**Prevention:**
+1. Establish a strict validation function (`is_safe_url`) that checks URLs against known private, loopback, and reserved IP ranges.
+2. Disable automatic redirect following (`follow_redirects=False`) on HTTP clients when fetching user-provided URLs.
+3. Handle redirects manually and run the validation check (`await is_safe_url()`) on the target URL of every single hop to prevent malicious actors from using a safe external URL that redirects to an internal, vulnerable endpoint.

--- a/functions/security_utils.py
+++ b/functions/security_utils.py
@@ -5,6 +5,10 @@ Contains helper functions for input sanitization and security.
 
 import re
 import hashlib
+import asyncio
+import socket
+import ipaddress
+from urllib.parse import urlparse
 
 def escape_markdown_v1(text: str) -> str:
     """
@@ -39,3 +43,45 @@ def stable_hash(value: str) -> str:
     if not value:
         value = ""
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+async def is_safe_url(url: str) -> bool:
+    """
+    Validates a URL to prevent Server-Side Request Forgery (SSRF).
+    Rejects non-http(s) schemes, internal IPs, loopback, and reserved addresses.
+
+    Args:
+        url: The URL string to validate.
+
+    Returns:
+        True if the URL is safe to fetch, False otherwise.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ('http', 'https'):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        loop = asyncio.get_running_loop()
+
+        # Resolve hostname to IP address
+        addr_info = await loop.getaddrinfo(hostname, None, family=socket.AF_UNSPEC, type=socket.SOCK_STREAM)
+
+        for info in addr_info:
+            ip_str = info[4][0]
+            ip = ipaddress.ip_address(ip_str)
+
+            # Reject loopback, private, multicast, and other special addresses
+            if (ip.is_loopback or
+                ip.is_private or
+                ip.is_multicast or
+                ip.is_reserved or
+                ip.is_link_local):
+                return False
+
+        return True
+    except Exception:
+        # If parsing or DNS resolution fails, treat as unsafe
+        return False

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1770,9 +1770,34 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
     await query.answer(t('summarizing_link', user_lang))
 
     try:
-        # Fetch content
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url)
+        from .security_utils import is_safe_url
+        import urllib.parse
+
+        # Fetch content safely, mitigating SSRF and redirect loops
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            current_url = url
+            redirect_count = 0
+            response = None
+
+            while redirect_count < 5:
+                if not await is_safe_url(current_url):
+                    await query.message.reply_text("The provided link is not safe to process.")
+                    return
+
+                response = await client.get(current_url)
+
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        break
+                    current_url = urllib.parse.urljoin(current_url, location)
+                    redirect_count += 1
+                else:
+                    break
+
+            if response is None:
+                raise Exception("Failed to fetch content")
+
             response.raise_for_status()
 
         # Parse content safely


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) in `summarize_url_callback`. The bot was fetching user-provided URLs with native HTTP redirect following (`follow_redirects=True`). Malicious actors could supply external URLs that redirected to internal, private, or loopback IPs (e.g., `127.0.0.1`, `169.254.169.254`), allowing them to access internal services or instance metadata.
🎯 **Impact:** An attacker could bypass firewall rules, access local services, or exfiltrate sensitive cloud metadata (if running in GCP/AWS).
🔧 **Fix:** 
1. Added an asynchronous `is_safe_url` validation utility to strictly check resolved IPs against reserved, loopback, and private address blocks.
2. Disabled automatic redirect following (`follow_redirects=False`) on `httpx.AsyncClient` in `telegram_bot.py`.
3. Implemented manual redirect handling (limited to 5 hops) that validates the target URL on every single hop using `await is_safe_url()`.
✅ **Verification:** Verified by unit tests mapping various unsafe URL vectors (e.g., `localhost`, `file://`, private IPs, metadata endpoint) and ensuring they are rejected, and successfully executed `py_compile` on modified files.

---
*PR created automatically by Jules for task [9661327867776562515](https://jules.google.com/task/9661327867776562515) started by @AminSS99*