### PR TITLE
✨ [UX Improvement] Add fallback mechanism for expired temporary URLs in summarize_url_callback

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1764,6 +1764,17 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
     url = get_temp_url(url_hash, telegram_id)
 
     if not url:
+        from .user_storage import get_all_saved_articles
+        from .security_utils import stable_hash
+
+        articles = get_all_saved_articles(telegram_id)
+        for article in articles:
+            article_url = article.get('url', '')
+            if stable_hash(article_url)[:8] == url_hash:
+                url = article_url
+                break
+
+    if not url:
         await query.answer("Link expired. Please send the link again.", show_alert=True)
         return
 


### PR DESCRIPTION
Added a robust fallback for expired temporary URLs when users attempt to summarize a previously saved link.

When a temporary URL expires from the cache (`get_temp_url`), instead of giving a "Link expired" error, the bot iterates over the user's permanent saved articles using `get_all_saved_articles`. It tries to find the URL by matching `stable_hash(article_url)[:8]` to the given callback hash. This UX enhancement significantly minimizes friction, preventing the need for users to manually resubmit expired links that they have already saved.

---
*PR created automatically by Jules for task [10049337414345009324](https://jules.google.com/task/10049337414345009324) started by @AminSS99*