### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Server-Side Request Forgery (SSRF) in URL summarization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** MD5 and SHA-1 algorithms were being used for cryptographic hashes (e.g. `hashlib.md5` and `hashlib.sha1`) in several modules (`functions/cache.py`, `functions/telegram_bot.py`, `functions/user_storage.py`).
 **Learning:** Usage of insecure algorithms like MD5 and SHA1 poses a security risk due to known vulnerabilities and collision weaknesses. Even when used for non-critical identifiers, it is a bad practice and violates security policies.
 **Prevention:** Establish and strictly enforce a coding standard that mandates the use of modern, secure hash functions (such as SHA-256) for all hashing purposes. Here, we implemented a centralized `stable_hash` utility (using SHA-256) to ensure consistent and secure hashing across the codebase.
+
+## 2024-05-18 - [SSRF vulnerability in URL summarization]
+**Vulnerability:** Server-Side Request Forgery (SSRF) in `summarize_url_callback` and potentially other places that fetch user-provided URLs. The bot doesn't check if the URL resolves to local, loopback, or private networks before making an HTTP request via `httpx`.
+**Learning:** Telegram bots often accept links from users. Any link fetching mechanism can be abused to probe internal network services if input isn't validated properly.
+**Prevention:** Implement `is_safe_url` checking to reject non-public IPs.

--- a/functions/security_utils.py
+++ b/functions/security_utils.py
@@ -5,6 +5,9 @@ Contains helper functions for input sanitization and security.
 
 import re
 import hashlib
+import asyncio
+import ipaddress
+import urllib.parse
 
 def escape_markdown_v1(text: str) -> str:
     """
@@ -39,3 +42,34 @@ def stable_hash(value: str) -> str:
     if not value:
         value = ""
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+async def is_safe_url(url: str) -> bool:
+    """
+    Validates a URL to prevent Server-Side Request Forgery (SSRF).
+    Checks if the hostname resolves to a safe, public IP address.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False
+
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+
+        loop = asyncio.get_running_loop()
+        # Non-blocking DNS resolution
+        addr_info = await loop.getaddrinfo(hostname, None)
+
+        # Check all resolved IPs for safety
+        for addr in addr_info:
+            ip_str = addr[4][0]
+            ip = ipaddress.ip_address(ip_str)
+
+            # Reject loopback, private, multicast, reserved
+            if ip.is_loopback or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_link_local or ip.is_unspecified:
+                return False
+
+        return True
+    except Exception:
+        return False

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1770,9 +1770,43 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
     await query.answer(t('summarizing_link', user_lang))
 
     try:
-        # Fetch content
-        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-            response = await client.get(url)
+        from .security_utils import is_safe_url
+        import urllib.parse
+
+        # Initial SSRF check
+        if not await is_safe_url(url):
+            await query.message.reply_text("Unsafe URL detected.")
+            return
+
+        # Fetch content with manual redirect handling for full SSRF protection
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
+            current_url = url
+            redirect_count = 0
+            max_redirects = 5
+            response = None
+
+            while redirect_count < max_redirects:
+                response = await client.get(current_url)
+
+                if response.status_code in (301, 302, 303, 307, 308):
+                    location = response.headers.get("location")
+                    if not location:
+                        break
+
+                    next_url = urllib.parse.urljoin(current_url, location)
+                    if not await is_safe_url(next_url):
+                        await query.message.reply_text("Unsafe redirection URL detected.")
+                        return
+
+                    current_url = next_url
+                    redirect_count += 1
+                else:
+                    break
+
+            if response is None:
+                await query.message.reply_text("Could not fetch the URL.")
+                return
+
             response.raise_for_status()
 
         # Parse content safely


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Server-Side Request Forgery (SSRF) existed in `summarize_url_callback` because it fetched user-provided URLs using `httpx` without verifying if the target host resolved to a safe public IP. This could allow probing of internal networks or loopback addresses.
🎯 **Impact**: A malicious user could force the bot to make requests to private or internal systems (e.g. cloud metadata servers like `169.254.169.254` or internal services on `127.0.0.1`), leading to information disclosure or further compromise.
🔧 **Fix**: Added `is_safe_url` in `functions/security_utils.py` which performs non-blocking DNS resolution and uses `ipaddress` to reject loopback, private, multicast, reserved, and link-local IP addresses. Updated `summarize_url_callback` to use this check. Crucially, `follow_redirects` was set to `False` in the `httpx` client, and a manual redirect loop (max 5 redirects) was added to ensure that every hop in a redirect chain is independently validated against `is_safe_url`.
✅ **Verification**: Run `python3 -m pytest` from the root directory to verify tests pass. Also documented this learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15721339135330435069](https://jules.google.com/task/15721339135330435069) started by @AminSS99*