### PR TITLE
✨ Add `/stats` command for saved articles breakdown

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -956,6 +956,47 @@ async def filter_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(message, disable_web_page_preview=True)
 
 
+async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /stats command - show breakdown of saved articles by category."""
+    from .user_storage import get_all_saved_articles, get_user_language
+    from .translations import t
+
+    telegram_id = update.effective_user.id
+    user_lang = get_user_language(telegram_id)
+
+    articles = get_all_saved_articles(telegram_id)
+
+    if not articles:
+        await update.message.reply_text(t('stats_empty', user_lang), parse_mode='Markdown')
+        return
+
+    categories_count = {}
+    for article in articles:
+        category = article.get('category', 'tech')
+        categories_count[category] = categories_count.get(category, 0) + 1
+
+    cat_emoji = {
+        'ai': '🤖', 'security': '🔒', 'crypto': '💰', 'startups': '🚀',
+        'hardware': '💻', 'software': '📱', 'tech': '🔧'
+    }
+
+    message = t('stats_header', user_lang)
+
+    # Sort categories by count (descending)
+    sorted_categories = sorted(categories_count.items(), key=lambda x: x[1], reverse=True)
+
+    for category, count in sorted_categories:
+        cat_label = t(f'cat_{category}', user_lang)
+        message += f"{cat_label}: {count}\n"
+
+    message += t('stats_total', user_lang, total=len(articles))
+
+    try:
+        await update.message.reply_text(message, parse_mode='Markdown')
+    except Exception:
+        await update.message.reply_text(message)
+
+
 async def recap_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle /recap command - show weekly summary of saved articles."""
     from .user_storage import get_saved_articles, get_user_language
@@ -1939,6 +1980,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("semsearch", "Semantic search saved"),
         BotCommand("filter", "Filter saved by category"),
         BotCommand("recap", "Weekly saved articles recap"),
+        BotCommand("stats", "View saved articles stats"),
         BotCommand("status", "View your settings"),
         BotCommand("language", "Change language"),
         BotCommand("sources", "Toggle news sources"),
@@ -1962,6 +2004,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("semsearch", "Умный поиск"),
         BotCommand("filter", "Фильтр по категориям"),
         BotCommand("recap", "Еженедельная сводка"),
+        BotCommand("stats", "Статистика сохранённых статей"),
         BotCommand("status", "Настройки"),
         BotCommand("language", "Язык"),
         BotCommand("sources", "Источники новостей"),
@@ -2031,6 +2074,7 @@ def create_bot_application() -> Application:
     application.add_handler(CommandHandler("language", language_command))
     application.add_handler(CommandHandler("filter", filter_command))
     application.add_handler(CommandHandler("recap", recap_command))
+    application.add_handler(CommandHandler("stats", stats_command))
     application.add_handler(CommandHandler("share", share_command))
     application.add_handler(CommandHandler("trends", trends_command))
     application.add_handler(CommandHandler("timezone", timezone_command))

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -128,6 +128,10 @@ Use /sources to toggle sources""",
         'clear_all_prompt': "⚠️ **Are you sure you want to delete ALL saved articles?**\n\nThis action cannot be undone.",
         'clear_all_confirm_btn': "✅ Yes, delete all",
         'clear_all_cancel_btn': "❌ Cancel",
+        'cleared_saved': "✅ All saved articles have been deleted.",
+        'stats_header': "📊 **Your Reading Profile**\n_Here is a breakdown of your saved articles:_\n\n",
+        'stats_empty': "📊 **Your Reading Profile**\n\nYou haven't saved any articles yet. Start saving articles to see your reading stats!",
+        'stats_total': "\n_Total saved articles: {total}_",
         
         # Category labels
         'cat_ai': "🤖 AI",
@@ -272,6 +276,10 @@ _Работает локально - настройки сохранятся п�
         'clear_all_prompt': "⚠️ **Вы уверены, что хотите удалить ВСЕ сохранённые статьи?**\n\nЭто действие нельзя отменить.",
         'clear_all_confirm_btn': "✅ Да, удалить всё",
         'clear_all_cancel_btn': "❌ Отмена",
+        'cleared_saved': "✅ Все сохранённые статьи были удалены.",
+        'stats_header': "📊 **Ваш профиль чтения**\n_Вот статистика ваших сохранённых статей:_\n\n",
+        'stats_empty': "📊 **Ваш профиль чтения**\n\nВы еще не сохранили ни одной статьи. Начните сохранять статьи, чтобы увидеть статистику!",
+        'stats_total': "\n_Всего сохранено статей: {total}_",
         
         # Category labels
         'cat_ai': "🤖 ИИ",

--- a/test_stats_feature.py
+++ b/test_stats_feature.py
@@ -1,0 +1,93 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+import sys
+import os
+sys.path.insert(0, os.path.abspath('functions'))
+
+from functions.telegram_bot import stats_command
+
+@pytest.mark.asyncio
+@patch('functions.telegram_bot.get_user_language', return_value='en', create=True)
+@patch('functions.telegram_bot.get_all_saved_articles', return_value=[], create=True)
+@patch('functions.translations.t')
+async def test_stats_command_empty(mock_t, mock_get_all_saved_articles, mock_get_user_language):
+    # Setup mocks
+    mock_get_user_language.return_value = 'en'
+    mock_get_all_saved_articles.return_value = []
+
+    # We patch `t` globally because we're patching creating things that don't exist directly on `telegram_bot`.
+    def mock_t_func(key, lang, **kwargs):
+        if key == 'stats_empty':
+            return "You haven't saved any articles yet."
+        elif key == 'stats_header':
+            return "Your Reading Profile"
+        elif key == 'stats_total':
+            return f"\nTotal saved articles: {kwargs.get('total')}"
+        elif key.startswith('cat_'):
+            return key.replace('cat_', '').title()
+        return key
+    mock_t.side_effect = mock_t_func
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message = AsyncMock()
+
+    context = MagicMock()
+
+    # Run
+    # Use patch to inject the imports
+    with patch('functions.user_storage.get_user_language', return_value='en'), \
+         patch('functions.user_storage.get_all_saved_articles', return_value=[]), \
+         patch('functions.translations.t', side_effect=mock_t_func):
+        await stats_command(update, context)
+
+    # Verify
+    update.message.reply_text.assert_called_once()
+    args, kwargs = update.message.reply_text.call_args
+    assert "You haven't saved any articles yet" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_stats_command_with_articles():
+    # Setup mocks
+    def mock_t_func(key, lang, **kwargs):
+        if key == 'stats_empty':
+            return "You haven't saved any articles yet."
+        elif key == 'stats_header':
+            return "Your Reading Profile\n"
+        elif key == 'stats_total':
+            return f"\nTotal saved articles: {kwargs.get('total')}"
+        elif key.startswith('cat_'):
+            return key.replace('cat_', '').title()
+        return key
+
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.message = AsyncMock()
+
+    context = MagicMock()
+
+    # Run
+    articles = [
+        {'title': '1', 'url': 'a', 'category': 'ai'},
+        {'title': '2', 'url': 'b', 'category': 'ai'},
+        {'title': '3', 'url': 'c', 'category': 'security'},
+        {'title': '4', 'url': 'd', 'category': 'tech'},
+    ]
+    with patch('functions.user_storage.get_user_language', return_value='en'), \
+         patch('functions.user_storage.get_all_saved_articles', return_value=articles), \
+         patch('functions.translations.t', side_effect=mock_t_func):
+        await stats_command(update, context)
+
+    # Verify
+    update.message.reply_text.assert_called_once()
+    args, kwargs = update.message.reply_text.call_args
+    text = args[0]
+
+    # Sort order: AI (2) > Security (1), Tech (1)
+    assert "Your Reading Profile" in text
+    assert "Ai: 2" in text
+    assert "Security: 1" in text
+    assert "Tech: 1" in text
+    assert "Total saved articles: 4" in text


### PR DESCRIPTION
Added a new feature, the `/stats` command, which allows users to view a breakdown of their saved articles by category (AI, Security, Crypto, etc.). It displays the total count per category and the overall total. The UI correctly handles empty states and incorporates proper translations for English and Russian locales.

---
*PR created automatically by Jules for task [1044844377600730710](https://jules.google.com/task/1044844377600730710) started by @AminSS99*