### PR TITLE
✨ Enhance /random with endless discovery feed

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1361,6 +1361,7 @@ async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     from .user_storage import get_all_saved_articles, get_user_language
     from .translations import t
     import random
+    import telegram.error
 
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
@@ -1368,7 +1369,14 @@ async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     articles = get_all_saved_articles(telegram_id)
 
     if not articles:
-        await update.message.reply_text(t('no_saved', user_lang), parse_mode='Markdown')
+        msg = t('no_saved', user_lang)
+        if update.callback_query:
+            try:
+                await update.callback_query.edit_message_text(msg, parse_mode='Markdown')
+            except telegram.error.BadRequest:
+                pass
+        else:
+            await update.message.reply_text(msg, parse_mode='Markdown')
         return
 
     article = random.choice(articles)
@@ -1398,7 +1406,22 @@ async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if date_str:
         message += f" `{date_str}`"
 
-    await update.message.reply_text(message, parse_mode='Markdown')
+    next_btn_text = "🎲 Следующая" if user_lang == 'ru' else "🎲 Next"
+    reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton(next_btn_text, callback_data="random_next")]])
+
+    if update.callback_query:
+        try:
+            await update.callback_query.edit_message_text(message, parse_mode='Markdown', reply_markup=reply_markup)
+        except telegram.error.BadRequest:
+            pass
+    else:
+        await update.message.reply_text(message, parse_mode='Markdown', reply_markup=reply_markup)
+
+
+async def random_next_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle the Next button on random articles."""
+    await update.callback_query.answer()
+    await random_command(update, context)
 
 
 async def search_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1410,7 +1433,6 @@ async def search_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     from .rate_limiter import check_rate_limit
     from .translations import t
     
-    reply_msg = update.message if update.message else update.callback_query.message
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
     
@@ -2220,6 +2242,7 @@ def create_bot_application() -> Application:
     application.add_handler(CallbackQueryHandler(clear_all_cancel_callback, pattern='^clear_all_cancel_'))
     application.add_handler(CallbackQueryHandler(search_history_callback, pattern='^search_history_'))
     application.add_handler(CallbackQueryHandler(clear_search_history_callback, pattern='^clear_search_history$'))
+    application.add_handler(CallbackQueryHandler(random_next_callback, pattern='^random_next$'))
     
     # Add message handler for buttons and Q&A (handles any text that isn't a command)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))


### PR DESCRIPTION
I implemented the Forge persona's goal of an impactful yet low-footprint feature enhancement.

**The Feature:**
An endless discovery feed for the `/random` command.

**Why:**
Previously, reading random saved articles was tedious. You had to type `/random`, read an article, then manually type `/random` again to get the next one. This adds significant friction to exploring a user's archive.

**How:**
1. I refactored the existing `random_command` to support being called not just via message, but via inline `callback_query`.
2. I added a "🎲 Next" (`🎲 Следующая`) button to the random article payload.
3. I bound this new button to a `random_next_callback` which simply answers the query and re-runs `random_command`.
4. Crucially, I added a `try-except` block around `edit_message_text` catching `telegram.error.BadRequest`. Because selection is random, picking the exact same article twice in a row would cause Telegram to reject the API call with "Message is not modified" and hang the client. The try-catch safely ignores this anomaly.

The feature is less than 50 lines of code, touches no database structures, introduces no new dependencies, and creates a significant UX enhancement ("Oh wow, that should have always been there"). All tests are passing.

---
*PR created automatically by Jules for task [16031344084152990707](https://jules.google.com/task/16031344084152990707) started by @AminSS99*