### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing Telegram webhook verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** In `summarize_url_callback`, `httpx.AsyncClient` used `follow_redirects=True` with unvalidated user-provided URLs. This could allow an attacker to bypass domain checks via a 301/302 redirect and force the bot to fetch sensitive internal network services (like cloud metadata on `169.254.169.254` or local host services), leading to a Server-Side Request Forgery (SSRF) attack.
 **Learning:** Automatically following redirects via HTTP clients (like `httpx` or `requests`) defeats URL-based domain validation filters because the client will silently hop to an internal IP address without re-evaluating safety.
 **Prevention:** To prevent SSRF, always disable automatic redirects (`follow_redirects=False`), manually inspect the `Location` header, and independently evaluate *every single hop* of the redirect chain against strict IP restrictions (e.g., rejecting `ip.is_link_local`, `ip.is_unspecified`, and non-`is_global`) using asynchronous DNS resolution (`asyncio.get_running_loop().getaddrinfo(hostname, None)`).
+
+## 2024-04-16 - [HIGH] Missing Telegram Webhook Secret Token Validation
+**Vulnerability:** The Telegram webhook handler in `functions/main.py` accepted incoming requests without verifying the `X-Telegram-Bot-Api-Secret-Token` header against a stored secret.
+**Learning:** Any endpoint configured as a webhook should authenticate the sender. Without validation, anyone who discovers the webhook URL can send forged updates to the bot.
+**Prevention:** Implement webhook sender validation using secrets provided in headers (such as `X-Telegram-Bot-Api-Secret-Token` for Telegram) and verify them against environment variables before processing any payload.

--- a/functions/main.py
+++ b/functions/main.py
@@ -29,6 +29,13 @@ def telegram_webhook(request: Request):
     
     if request.method != 'POST':
         return 'OK', 200
+
+    secret_token = os.environ.get("TELEGRAM_WEBHOOK_SECRET_TOKEN")
+    if secret_token:
+        header_token = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if header_token != secret_token:
+            print("WARNING: Webhook secret token mismatch")
+            return 'Forbidden', 403
     
     try:
         # Parse the incoming update


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Telegram webhook handler in `functions/main.py` accepted incoming requests without verifying the `X-Telegram-Bot-Api-Secret-Token` header.
🎯 **Impact:** Anyone who discovers the webhook URL could send forged payload updates to the bot.
🔧 **Fix:** Added validation of the `X-Telegram-Bot-Api-Secret-Token` header against the `TELEGRAM_WEBHOOK_SECRET_TOKEN` environment variable. If the env var is set and the headers mismatch, the endpoint now returns a 403 Forbidden.
✅ **Verification:** Verified by checking the `main.py` diff and running tests to ensure no syntax errors or regressions were introduced.

---
*PR created automatically by Jules for task [12075480760257972180](https://jules.google.com/task/12075480760257972180) started by @AminSS99*