### PR TITLE
✨ Add admin command to clear digest cache

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1354,7 +1354,27 @@ async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 # ============ ADMIN STATUS ============
 
+
+async def clearcache_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /clearcache command - clear all cache (Admin only)."""
+    from .translations import t
+    from .user_storage import get_user_language
+
+    telegram_id = update.effective_user.id
+    user_lang = get_user_language(telegram_id)
+
+    admin_ids = get_admin_ids()
+    if telegram_id not in admin_ids:
+        await update.message.reply_text(t('unauthorized_admin', user_lang))
+        return
+
+    from .cache import clear_cached_digest
+    clear_cached_digest("*")
+
+    await update.message.reply_text(t('clearcache_success', user_lang))
+
 # ============ SEARCH ============
+
 
 async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle /random command - get a random saved article."""
@@ -2110,6 +2130,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("admin_status", "Admin observability"),
         BotCommand("share", "Share bot with friends"),
         BotCommand("trends", "Weekly topic trends"),
+        BotCommand("clearcache", "Clear system cache (Admin)"),
         BotCommand("help", "Show help"),
     ]
     
@@ -2135,6 +2156,7 @@ async def setup_bot_commands(application: Application):
         BotCommand("admin_status", "Статус системы"),
         BotCommand("share", "Поделиться ботом"),
         BotCommand("trends", "Тренды недели"),
+        BotCommand("clearcache", "Очистить системный кэш (Админ)"),
         BotCommand("help", "Помощь"),
     ]
     
@@ -2203,6 +2225,7 @@ def create_bot_application() -> Application:
     application.add_handler(CommandHandler("trendalerts", trendalerts_command))
     application.add_handler(CommandHandler("semsearch", semantic_search_command))
     application.add_handler(CommandHandler("admin_status", admin_status_command))
+    application.add_handler(CommandHandler("clearcache", clearcache_command))
     
     # Add callback query handlers for inline buttons
     application.add_handler(CallbackQueryHandler(toggle_source_callback, pattern='^toggle_'))

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -136,6 +136,10 @@ Use /sources to toggle sources""",
         'stats_total': "*Total Saved:* {total}\n",
         'stats_top_sources': "\n*Top Sources:*\n",
 
+        # Admin
+        'clearcache_success': "✅ All cache entries have been successfully cleared!",
+        'unauthorized_admin': "⛔ Unauthorized. This command is restricted to administrators.",
+
         # Category labels
         'cat_ai': "🤖 AI",
         'cat_security': "🔒 Security",
@@ -286,6 +290,10 @@ _Работает локально - настройки сохранятся п�
         'stats_header': "📊 *Ваша статистика чтения*\n\n",
         'stats_total': "*Всего сохранено:* {total}\n",
         'stats_top_sources': "\n*Топ источников:*\n",
+
+        # Admin
+        'clearcache_success': "✅ Все записи кэша успешно удалены!",
+        'unauthorized_admin': "⛔ Отказано в доступе. Эта команда доступна только администраторам.",
 
         # Category labels
         'cat_ai': "🤖 ИИ",


### PR DESCRIPTION
Adds the `/clearcache` command to `telegram_bot.py` specifically restricted to administrators. It utilizes the `clear_cached_digest("*")` function from `cache.py` to seamlessly wipe all cached entries in Firestore. The appropriate success messages have also been added to `translations.py`.

---
*PR created automatically by Jules for task [10404604636045312677](https://jules.google.com/task/10404604636045312677) started by @AminSS99*