### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing Telegram webhook authentication

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -7,6 +7,7 @@ import os
 import json
 import asyncio
 import traceback
+import hmac
 from datetime import datetime
 from zoneinfo import ZoneInfo
 import functions_framework
@@ -29,6 +30,12 @@ def telegram_webhook(request: Request):
     
     if request.method != 'POST':
         return 'OK', 200
+
+    secret_token = os.environ.get('TELEGRAM_WEBHOOK_SECRET_TOKEN')
+    if secret_token:
+        header_token = request.headers.get('X-Telegram-Bot-Api-Secret-Token', '')
+        if not hmac.compare_digest(secret_token, header_token):
+            return 'Forbidden', 403
     
     try:
         # Parse the incoming update


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `telegram_webhook` endpoint in `functions/main.py` was fully open and did not verify the `X-Telegram-Bot-Api-Secret-Token` header. Anyone who discovered the endpoint URL could send fake payloads to the bot, causing it to send spam, interact with unintended endpoints, or potentially leak information depending on the bot's capabilities.
🎯 **Impact:** An attacker could completely impersonate the Telegram API, taking control of how the bot receives inputs and processes updates.
🔧 **Fix:** I imported `hmac` and added a check at the beginning of `telegram_webhook` that verifies if the `X-Telegram-Bot-Api-Secret-Token` from the HTTP headers matches the environment variable `TELEGRAM_WEBHOOK_SECRET_TOKEN`. I specifically used `hmac.compare_digest` to prevent timing attacks.
✅ **Verification:** Verified syntax manually and ran `pytest` on the local pyenv environment to ensure there were no regressions in existing tests. The endpoint now effectively returns a 403 Forbidden for unauthorized requests if the secret token is set.

---
*PR created automatically by Jules for task [8959335208949657088](https://jules.google.com/task/8959335208949657088) started by @AminSS99*