### PR TITLE
feat: auto-fetch and parse webpage title for saved URLs

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -2153,11 +2153,32 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if user_message.startswith('http://') or user_message.startswith('https://'):
         from .user_storage import save_article, save_temp_url
         from .security_utils import stable_hash
+        import httpx
+        from bs4 import BeautifulSoup
+        import asyncio
+        from telegram import constants
 
-        is_saved = save_article(telegram_id, user_message[:50], user_message)
+        chat_id = update.effective_chat.id
+        await context.bot.send_chat_action(chat_id=chat_id, action=constants.ChatAction.TYPING)
 
-        url_hash = stable_hash(user_message)[:8]
-        save_temp_url(url_hash, telegram_id, user_message)
+        url = user_message.strip()
+        title = url[:50]
+
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                response = await client.get(url, follow_redirects=True)
+                if response.status_code == 200:
+                    soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
+                    title_tag = soup.find('title')
+                    if title_tag and title_tag.string:
+                        title = title_tag.string.strip()[:100]
+        except Exception as e:
+            print(f"Error fetching title for {url}: {e}")
+
+        is_saved = save_article(telegram_id, title, url)
+
+        url_hash = stable_hash(url)[:8]
+        save_temp_url(url_hash, telegram_id, url)
 
         reply_markup = InlineKeyboardMarkup([
             [InlineKeyboardButton(t('btn_summarize', user_lang), callback_data=f"summarize_url_{url_hash}")]


### PR DESCRIPTION
This PR implements a meaningful feature enhancement for the Telegram bot. Previously, when a user sent a raw URL to save, the bot would immediately save it using the first 50 characters of the URL as the title. Now, the bot asynchronously fetches the actual HTML of the provided URL and extracts the `<title>` tag using BeautifulSoup. This title is then used to properly categorize and save the article in Firestore, greatly improving the reading and bookmarking experience. The fetch is wrapped in `asyncio.to_thread` to ensure the bot's event loop is not blocked during HTML parsing, and it falls back safely if the fetch times out or fails.

---
*PR created automatically by Jules for task [10118172553304088153](https://jules.google.com/task/10118172553304088153) started by @AminSS99*