### PR TITLE
✨ [feature enhancement] Allow exporting saved articles by category

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -849,7 +849,9 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
-    articles = get_all_saved_articles(telegram_id)
+
+    category_filter = context.args[0].lower() if context.args else None
+    articles = get_all_saved_articles(telegram_id, category=category_filter)
 
     if not articles:
         await update.message.reply_text(t('export_empty', user_lang), parse_mode='Markdown')
@@ -882,7 +884,8 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         lines.append("")
 
     document = io.BytesIO("\n".join(lines).encode('utf-8'))
-    document.name = f"lensai_saved_articles_{datetime.now().strftime('%Y%m%d')}.md"
+    filename_category = f"_{category_filter}" if category_filter else ""
+    document.name = f"lensai_saved_articles{filename_category}_{datetime.now().strftime('%Y%m%d')}.md"
 
     await update.message.reply_document(
         document=document,


### PR DESCRIPTION
🎯 **What**
Added the ability to filter exported saved articles by category (e.g., `/export ai`).

💡 **Why**
Users with many saved articles often want to export a specific subset (like just "crypto" or "ai" news) instead of their entire list. The underlying storage function `get_all_saved_articles` already supported a `category` parameter, so this exposes that functionality to the UI.

✅ **Verification**
- Modified `functions/telegram_bot.py` using search-and-replace to extract `context.args`.
- Validated via `git diff` that the correct parameters are passed.
- Successfully ran the pytest suite on the codebase (`PYTHONPATH=functions pytest test*.py`).

✨ **Result**
Users can now optionally provide a category argument to `/export`, generating tailored Markdown exports with corresponding filenames (e.g., `lensai_saved_articles_ai_20240101.md`).

---
*PR created automatically by Jules for task [14457419242221966167](https://jules.google.com/task/14457419242221966167) started by @AminSS99*