### PR TITLE
✨ Forge: Add Summarize buttons to filtered articles

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1046,17 +1046,27 @@ async def filter_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     cat_label = t(f'cat_{category}', user_lang)
     message = t('filter_results', user_lang, category=cat_label, count=len(articles))
     
-    from .security_utils import sanitize_markdown_url
+    from .security_utils import sanitize_markdown_url, stable_hash
+    keyboard = []
     for i, article in enumerate(articles, 1):
         title = article.get('title', 'Untitled')[:50]
-        url = sanitize_markdown_url(article.get('url', ''))
+        raw_url = article.get('url', '')
+        url = sanitize_markdown_url(raw_url)
         if url.startswith('http'):
             message += f"{i}. [{title}]({url})\n"
         else:
             message += f"{i}. {title}\n"
 
+        # Create summarize button for each item
+        if url.startswith('http'):
+            url_hash = stable_hash(raw_url)[:8]
+            summarize_label = t('btn_summarize', user_lang)
+            keyboard.append([
+                InlineKeyboardButton(f"🧠 {i}. {summarize_label}", callback_data=f"summarize_url_{url_hash}")
+            ])
+
     # Add a back button
-    keyboard = [[InlineKeyboardButton("⬅️ Back to Categories" if user_lang == 'en' else "⬅️ Назад к категориям", callback_data="filter_menu")]]
+    keyboard.append([InlineKeyboardButton("⬅️ Back to Categories" if user_lang == 'en' else "⬅️ Назад к категориям", callback_data="filter_menu")])
     reply_markup = InlineKeyboardMarkup(keyboard)
     
     try:
@@ -2031,7 +2041,7 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
     url = get_temp_url(url_hash, telegram_id)
 
     if not url:
-        from .user_storage import get_all_saved_articles
+        from .user_storage import get_all_saved_articles, save_temp_url
         from .security_utils import stable_hash
 
         articles = get_all_saved_articles(telegram_id)
@@ -2039,6 +2049,7 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
             article_url = article.get('url', '')
             if stable_hash(article_url)[:8] == url_hash:
                 url = article_url
+                save_temp_url(url_hash, telegram_id, url)
                 break
 
     if not url:


### PR DESCRIPTION
🎯 **What**
Added inline "Summarize 🧠" buttons directly to the `/filter` command results list.

💡 **Why**
Previously, the `/filter` command only outputted a static markdown list of saved articles within a category. To summarize them, users had to either go back to `/saved` or manually extract the URL. This update embeds the interactive "Summarize" button directly in the filtered list, mirroring the functionality of the primary `/saved` view and vastly improving usability. Additionally, a fallback was added to `summarize_url_callback` to proactively cache URLs from `get_all_saved_articles` if they have expired from the temporary cache, eliminating silent failures.

✅ **Verification**
Ran all 25 unit tests via `pytest` to confirm that the changes integrate perfectly and introduce no regressions in formatting, escaping, or callback handling.

✨ **Result**
Users can now instantly generate AI summaries for articles while browsing their saved content by category, creating a smoother and significantly more powerful user experience.

---
*PR created automatically by Jules for task [8955272775486817378](https://jules.google.com/task/8955272775486817378) started by @AminSS99*