### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in URL processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The Telegram webhook and internal API endpoints in `functions/main.py` validated authorization headers (`X-Telegram-Bot-Api-Secret-Token` and `X-Internal-Secret`) using a simple string equality comparison (`!=`). This allowed attackers to potentially use timing attacks to guess the secret token byte by byte.
 **Learning:** Normal string comparison checks operators short-circuit, returning false on the first mismatched character. By measuring the precise time it takes for the server to reject a request, an attacker can determine how many characters of their guess were correct.
 **Prevention:** Always use constant-time comparison functions, such as `hmac.compare_digest()`, when verifying cryptographic materials like passwords, MACs, API tokens, or webhook secrets.
+## 2026-04-28 - [CRITICAL] Prevent SSRF in message URL saving
+**Vulnerability:** In `functions/telegram_bot.py`, the message handler that captures URLs and attempts to fetch their `<title>` used `httpx.AsyncClient` with `follow_redirects=True`. This allowed Server-Side Request Forgery (SSRF) bypasses where a safe-looking initial URL could redirect to an internal or link-local IP.
+**Learning:** Automatically following redirects defeats domain validation checks because the HTTP client silently follows the redirect to an unsafe IP.
+**Prevention:** To prevent SSRF, disable `follow_redirects=True`. Instead, use a loop to manually capture the `Location` header, resolve the redirect URL, and run `is_safe_url()` against every intermediate hop before fetching it.

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -2412,13 +2412,31 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         title = url[:50]
 
         try:
-            async with httpx.AsyncClient(timeout=3.0) as client:
-                response = await client.get(url, follow_redirects=True)
-                if response.status_code == 200:
-                    soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
-                    title_tag = soup.find('title')
-                    if title_tag and title_tag.string:
-                        title = title_tag.string.strip()[:100]
+            from .security_utils import is_safe_url
+            import urllib.parse
+
+            redirects = 0
+            current_url = url
+            response = None
+            async with httpx.AsyncClient(timeout=3.0, follow_redirects=False) as client:
+                while redirects < 5:
+                    if not await is_safe_url(current_url):
+                        break
+                    response = await client.get(current_url)
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get('Location')
+                        if not location:
+                            break
+                        current_url = urllib.parse.urljoin(current_url, location)
+                        redirects += 1
+                    else:
+                        break
+
+            if response and response.status_code == 200:
+                soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
+                title_tag = soup.find('title')
+                if title_tag and title_tag.string:
+                    title = title_tag.string.strip()[:100]
         except Exception as e:
             print(f"Error fetching title for {url}: {e}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF via HTTP Redirects. The bot extracted titles from URLs sent by users using `httpx.AsyncClient(follow_redirects=True)`. This defeats the `is_safe_url` domain validation, as an attacker could provide a URL that passes initial checks but redirects to `169.254.169.254` or local endpoints, exposing internal resources.
🎯 Impact: High. An attacker could potentially scan the internal network, access cloud metadata services, or perform actions as the server.
🔧 Fix: Set `follow_redirects=False` and implemented a manual redirect loop (max 5 hops) that ensures `is_safe_url` is called on *every* redirect target.
✅ Verification: Ran unit tests and manually verified `git diff` that `follow_redirects=True` has been safely replaced.

---
*PR created automatically by Jules for task [14039163736801375751](https://jules.google.com/task/14039163736801375751) started by @AminSS99*