### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in URL title fetcher

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The Telegram webhook and internal API endpoints in `functions/main.py` validated authorization headers (`X-Telegram-Bot-Api-Secret-Token` and `X-Internal-Secret`) using a simple string equality comparison (`!=`). This allowed attackers to potentially use timing attacks to guess the secret token byte by byte.
 **Learning:** Normal string comparison checks operators short-circuit, returning false on the first mismatched character. By measuring the precise time it takes for the server to reject a request, an attacker can determine how many characters of their guess were correct.
 **Prevention:** Always use constant-time comparison functions, such as `hmac.compare_digest()`, when verifying cryptographic materials like passwords, MACs, API tokens, or webhook secrets.
+
+## 2024-05-16 - Prevent SSRF with httpx follows_redirects
+**Vulnerability:** Found an SSRF vulnerability where `httpx.AsyncClient` was fetching user-provided URLs with `follow_redirects=True`. This bypassed the `is_safe_url` validation, allowing an attacker to provide a safe URL that redirects to an internal or link-local address.
+**Learning:** `follow_redirects=True` is dangerous for user-provided URLs, even if the initial URL is validated, because intermediate redirects are followed automatically without validation.
+**Prevention:** Always use `follow_redirects=False` and manually resolve redirects in a loop, running `await is_safe_url(current_url)` on the new `Location` target before following it.

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -2412,9 +2412,29 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         title = url[:50]
 
         try:
-            async with httpx.AsyncClient(timeout=3.0) as client:
-                response = await client.get(url, follow_redirects=True)
-                if response.status_code == 200:
+            from .security_utils import is_safe_url
+            import urllib.parse
+            current_url = url
+            redirects = 0
+            response = None
+            async with httpx.AsyncClient(timeout=3.0, follow_redirects=False) as client:
+                while redirects < 5:
+                    if not await is_safe_url(current_url):
+                        print(f"Security blocked access to URL: {current_url}")
+                        break
+
+                    response = await client.get(current_url)
+
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            break
+                        current_url = urllib.parse.urljoin(current_url, location)
+                        redirects += 1
+                    else:
+                        break
+
+                if response and response.status_code == 200:
                     soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
                     title_tag = soup.find('title')
                     if title_tag and title_tag.string:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `httpx.AsyncClient` was configured with `follow_redirects=True` when fetching user-provided URLs. Even if the initial URL is validated by `is_safe_url`, an attacker can provide a safe external URL that responds with a 3xx redirect to an internal IP or local address, bypassing the initial check and resulting in Server-Side Request Forgery (SSRF).
🎯 **Impact:** An attacker could exploit this to make the bot fetch internal network resources, local metadata endpoints, or perform actions against internal services.
🔧 **Fix:** Set `follow_redirects=False` and implemented a manual redirect following loop (up to 5 redirects). At each step, `current_url` is verified using the existing `is_safe_url` function, safely aborting if an unsafe target is reached.
✅ **Verification:** Ran pytest tests successfully, confirming no regressions. The SSRF behavior was manually tested and confirmed resolved.

---
*PR created automatically by Jules for task [16029509557376314989](https://jules.google.com/task/16029509557376314989) started by @AminSS99*