### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF in handle_message url fetcher

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The Telegram webhook and internal API endpoints in `functions/main.py` validated authorization headers (`X-Telegram-Bot-Api-Secret-Token` and `X-Internal-Secret`) using a simple string equality comparison (`!=`). This allowed attackers to potentially use timing attacks to guess the secret token byte by byte.
 **Learning:** Normal string comparison checks operators short-circuit, returning false on the first mismatched character. By measuring the precise time it takes for the server to reject a request, an attacker can determine how many characters of their guess were correct.
 **Prevention:** Always use constant-time comparison functions, such as `hmac.compare_digest()`, when verifying cryptographic materials like passwords, MACs, API tokens, or webhook secrets.
+## 2024-05-18 - Fix SSRF in handle_message url fetcher
+**Vulnerability:** The `handle_message` handler in `telegram_bot.py` accepted unvalidated URLs from users and used `httpx.AsyncClient` with `follow_redirects=True`. This could allow an attacker to bypass domain checks via a 301/302 redirect, leading to a Server-Side Request Forgery (SSRF) attack.
+**Learning:** Even simple URL preview/title fetchers are susceptible to SSRF if redirects are followed automatically without validating the target URL at each step.
+**Prevention:** Always set `follow_redirects=False` when using `httpx` with user-provided URLs. Implement a manual redirect loop (e.g., maximum 5 redirects) and validate the URL using an `is_safe_url` check at every step before making the next request.

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -2411,10 +2411,30 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         url = user_message.strip()
         title = url[:50]
 
+        from .security_utils import is_safe_url
+        import urllib.parse
+
         try:
-            async with httpx.AsyncClient(timeout=3.0) as client:
-                response = await client.get(url, follow_redirects=True)
-                if response.status_code == 200:
+            redirects = 0
+            current_url = url
+            response = None
+            async with httpx.AsyncClient(timeout=3.0, follow_redirects=False) as client:
+                while redirects < 5:
+                    if not await is_safe_url(current_url):
+                        break
+
+                    response = await client.get(current_url)
+
+                    if response.status_code in (301, 302, 303, 307, 308):
+                        location = response.headers.get("Location")
+                        if not location:
+                            break
+                        current_url = urllib.parse.urljoin(current_url, location)
+                        redirects += 1
+                    else:
+                        break
+
+                if response and response.status_code == 200:
                     soup = await asyncio.to_thread(BeautifulSoup, response.text, 'html.parser')
                     title_tag = soup.find('title')
                     if title_tag and title_tag.string:


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `handle_message` handler in `functions/telegram_bot.py` accepted unvalidated URLs from users and fetched them using `httpx.AsyncClient` with `follow_redirects=True`. This allowed the client to silently follow HTTP redirects (e.g., 301, 302) without validating the target URL.
🎯 **Impact:** An attacker could exploit this by providing a safe-looking URL that redirects to an internal network IP address (e.g., `127.0.0.1`, `169.254.169.254` for cloud metadata) or a local host service, leading to a Server-Side Request Forgery (SSRF) attack. This could expose sensitive internal services or cloud credentials.
🔧 **Fix:** Replaced the automatic redirect following with a manual redirect loop. The client is now configured with `follow_redirects=False`. During each redirect (up to a maximum of 5), the target `Location` URL is explicitly validated using the `is_safe_url` utility function before the bot attempts to fetch it.
✅ **Verification:** Ran `pytest` locally to confirm no regressions. Verified that `is_safe_url` correctly rejects local and reserved IP spaces.

---
*PR created automatically by Jules for task [8529170125860726708](https://jules.google.com/task/8529170125860726708) started by @AminSS99*