### PR TITLE
🧹 [Remove unused timedelta import from observability.py]

### DIFF
--- a/functions/observability.py
+++ b/functions/observability.py
@@ -4,7 +4,7 @@ Builds a simple runtime health snapshot for admin usage.
 """
 
 from typing import Dict, Any
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from collections import Counter
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `timedelta` import from `functions/observability.py`.
💡 **Why:** This improves maintainability by removing dead code, as flagged by static analysis. Keeping only used imports makes the code cleaner and less confusing.
✅ **Verification:** Verified the code changes using `git diff` and ran the full test suite (`pytest`) to confirm no functionality was broken. Code review confirmed the change is safe.
✨ **Result:** A cleaner `functions/observability.py` with no dead code imports.

---
*PR created automatically by Jules for task [17046146695594497483](https://jules.google.com/task/17046146695594497483) started by @AminSS99*