### PR TITLE
🧹 Remove unused timedelta import from stalker.py

### DIFF
--- a/functions/stalker.py
+++ b/functions/stalker.py
@@ -5,7 +5,7 @@ Users can stalk companies (to get news only from them) or GitHub repos (for rele
 
 import os
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
 
 import httpx


### PR DESCRIPTION
🎯 **What:** Removed the unused `timedelta` import from `functions/stalker.py`.
💡 **Why:** `timedelta` was imported but never utilized within the file. Removing it improves code health by reducing namespace clutter and adhering to clean code practices.
✅ **Verification:** Verified via `grep` that `timedelta` is no longer in the file and other `datetime` imports remain intact. Ran the project test suite to ensure no tests were broken.
✨ **Result:** A cleaner, more maintainable module without unnecessary imports.

---
*PR created automatically by Jules for task [15422582017994684761](https://jules.google.com/task/15422582017994684761) started by @AminSS99*