### PR TITLE
🧹 Remove unused timedelta import from observability.py

### DIFF
--- a/functions/observability.py
+++ b/functions/observability.py
@@ -4,7 +4,7 @@ Builds a simple runtime health snapshot for admin usage.
 """
 
 from typing import Dict, Any
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from collections import Counter
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `timedelta` import from `functions/observability.py`.
💡 **Why:** This removes dead code, reducing clutter and improving the readability and maintainability of the codebase. It resolves a minor static analysis code health issue.
✅ **Verification:** Verified the removal using `cat` and executed the full test suite (`pytest test*.py`) which passed successfully, confirming no functionality was broken.
✨ **Result:** The codebase is cleaner and adheres to better code health standards without any behavior changes.

---
*PR created automatically by Jules for task [1047234277160008455](https://jules.google.com/task/1047234277160008455) started by @AminSS99*