### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authorization bypass in internal API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The Telegram webhook and internal API endpoints in `functions/main.py` validated authorization headers (`X-Telegram-Bot-Api-Secret-Token` and `X-Internal-Secret`) using a simple string equality comparison (`!=`). This allowed attackers to potentially use timing attacks to guess the secret token byte by byte.
 **Learning:** Normal string comparison checks operators short-circuit, returning false on the first mismatched character. By measuring the precise time it takes for the server to reject a request, an attacker can determine how many characters of their guess were correct.
 **Prevention:** Always use constant-time comparison functions, such as `hmac.compare_digest()`, when verifying cryptographic materials like passwords, MACs, API tokens, or webhook secrets.
+## 2024-05-20 - Fail-Closed Authentication Check
+**Vulnerability:** A fail-open vulnerability existed in the `_require_internal_secret` authentication middleware where missing configuration (`INTERNAL_SECRET` not set) bypassed the authentication check completely, leaving protected internal endpoints exposed.
+**Learning:** Checking for the presence of the expected secret with `if expected and not (...)` inadvertently allows the check to pass if `expected` evaluates to `False` (like `None` or an empty string). Failsafe defaults require failing closed on misconfiguration.
+**Prevention:** Always use `if not expected or not (...)` for authentication token verifications against environment variables to ensure endpoints fail securely when configuration is missing.

--- a/functions/main.py
+++ b/functions/main.py
@@ -516,7 +516,7 @@ def _require_internal_secret(request: Request) -> tuple[bool, tuple]:
     """Verify that the request carries the correct internal secret header."""
     secret = request.headers.get("X-Internal-Secret")
     expected = os.environ.get("INTERNAL_SECRET")
-    if expected and not (secret and hmac.compare_digest(secret, expected)):
+    if not expected or not (secret and hmac.compare_digest(secret, expected)):
         return False, (json.dumps({"error": "Forbidden"}), 403)
     return True, ()
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A fail-open vulnerability was discovered in `_require_internal_secret` within `functions/main.py`. The original check `if expected and not (secret and hmac.compare_digest(secret, expected)):` would completely skip the authentication enforcement if the `INTERNAL_SECRET` environment variable was missing or unset (evaluating to `None`), implicitly returning `True` and granting access.
🎯 **Impact**: If a production instance is deployed without `INTERNAL_SECRET` configured, all internal administrative and scheduled endpoints (e.g., `/hourly_news_check`, `/process_deep_dives`) are completely exposed to unauthorized access without an authentication token, allowing unauthenticated remote triggering of administrative jobs.
🔧 **Fix**: Modified the validation condition to `if not expected or not (secret and hmac.compare_digest(secret, expected)):`. This guarantees that if the expected secret is not configured, the function fails securely (returning a 403 Forbidden) rather than failing open. 
✅ **Verification**: Wrote a dedicated test using `unittest.mock` demonstrating that when `INTERNAL_SECRET` is unset, the endpoint correctly returns `False` and a `403` status. The full test suite was run locally and passed successfully. Recorded this pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7767585472475093448](https://jules.google.com/task/7767585472475093448) started by @AminSS99*