### PR TITLE
✨ [add CSV export support for saved articles]

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -884,10 +884,11 @@ async def save_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Handle /export command - export saved articles as a Markdown file."""
+    """Handle /export command - export saved articles as a Markdown or CSV file."""
     from .translations import t
     from .user_storage import get_all_saved_articles, get_user_language
     import io
+    import csv
 
     def _clean_export_value(value) -> str:
         if value is None:
@@ -899,42 +900,76 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     telegram_id = update.effective_user.id
     user_lang = get_user_language(telegram_id)
 
-    category_filter = context.args[0].lower() if context.args else None
+    # Determine export format (csv or md) and category filter from args
+    export_format = 'md'
+    category_filter = None
+
+    if context.args:
+        args = [arg.lower() for arg in context.args]
+        if 'csv' in args:
+            export_format = 'csv'
+            args.remove('csv')
+        elif 'md' in args:
+            export_format = 'md'
+            args.remove('md')
+
+        if args:
+            category_filter = args[0]
+
     articles = get_all_saved_articles(telegram_id, category=category_filter)
 
     if not articles:
         await update.message.reply_text(t('export_empty', user_lang), parse_mode='Markdown')
         return
 
-    lines = [
-        "# LensAI Saved Articles",
-        "",
-        f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
-        f"Total articles: {len(articles)}",
-        "",
-    ]
-
-    for index, article in enumerate(articles, 1):
-        title = _clean_export_value(article.get('title')) or "Untitled"
-        url = _clean_export_value(article.get('url'))
-        source = _clean_export_value(article.get('source'))
-        category = article.get('category', 'tech') or 'tech'
-        category_label = _clean_export_value(t(f'cat_{category}', user_lang))
-        saved_at = _clean_export_value(article.get('saved_at'))
-
-        lines.append(f"## {index}. {title}")
-        lines.append(f"- Category: {category_label}")
-        if source:
-            lines.append(f"- Source: {source}")
-        if saved_at:
-            lines.append(f"- Saved: {saved_at}")
-        if url:
-            lines.append(f"- URL: <{url}>")
-        lines.append("")
-
-    document = io.BytesIO("\n".join(lines).encode('utf-8'))
     filename_category = f"_{category_filter}" if category_filter else ""
-    document.name = f"lensai_saved_articles{filename_category}_{datetime.now().strftime('%Y%m%d')}.md"
+
+    if export_format == 'csv':
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["Title", "URL", "Source", "Category", "Saved At"])
+
+        for article in articles:
+            title = _clean_export_value(article.get('title')) or "Untitled"
+            url = _clean_export_value(article.get('url'))
+            source = _clean_export_value(article.get('source'))
+            category = article.get('category', 'tech') or 'tech'
+            category_label = _clean_export_value(t(f'cat_{category}', user_lang))
+            saved_at = _clean_export_value(article.get('saved_at'))
+
+            writer.writerow([title, url, source, category_label, saved_at])
+
+        document = io.BytesIO(b'\xef\xbb\xbf' + output.getvalue().encode('utf-8'))
+        document.name = f"lensai_saved_articles{filename_category}_{datetime.now().strftime('%Y%m%d')}.csv"
+    else:
+        lines = [
+            "# LensAI Saved Articles",
+            "",
+            f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+            f"Total articles: {len(articles)}",
+            "",
+        ]
+
+        for index, article in enumerate(articles, 1):
+            title = _clean_export_value(article.get('title')) or "Untitled"
+            url = _clean_export_value(article.get('url'))
+            source = _clean_export_value(article.get('source'))
+            category = article.get('category', 'tech') or 'tech'
+            category_label = _clean_export_value(t(f'cat_{category}', user_lang))
+            saved_at = _clean_export_value(article.get('saved_at'))
+
+            lines.append(f"## {index}. {title}")
+            lines.append(f"- Category: {category_label}")
+            if source:
+                lines.append(f"- Source: {source}")
+            if saved_at:
+                lines.append(f"- Saved: {saved_at}")
+            if url:
+                lines.append(f"- URL: <{url}>")
+            lines.append("")
+
+        document = io.BytesIO("\n".join(lines).encode('utf-8'))
+        document.name = f"lensai_saved_articles{filename_category}_{datetime.now().strftime('%Y%m%d')}.md"
 
     await update.message.reply_document(
         document=document,

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -29,7 +29,7 @@ MESSAGES = {
         'article_exists': "ℹ️ Article already saved!",
         'cleared_saved': "🗑️ All saved articles cleared!",
         'export_empty': "🔖 **No saved articles to export yet!**\n\nSave an article first, then try `/export` again.",
-        'export_caption': "📚 **Saved Articles Export**\n\nExported {count} saved articles as a Markdown file.",
+        'export_caption': "📚 **Saved Articles Export**\n\nExported {count} saved articles.",
         'random_article_header': "🎲 **Random Pick for You**\n\n",
         'ai_error': "❌ Sorry, I couldn't process that: {error}",
         'refresh_limit': "✅ **You're all caught up!**\n\nI've generated 2 digests for you and you've seen the top news. Check back later for more updates!",
@@ -59,7 +59,7 @@ Use /settime to change it!""",
 🔖 **Saved Articles**
 • /save <url> - Save an article
 • /saved - View all saved articles
-• /export - Export saved articles as a Markdown file
+• /export [csv] - Export saved articles
 • /filter <category> - Filter by category (ai, security, crypto, startups, hardware, software, tech)
 • /recap - Weekly recap of saved articles
 • /clear_saved - Clear all saved articles
@@ -205,7 +205,7 @@ Use /sources to toggle sources""",
         'article_exists': "ℹ️ Статья уже сохранена!",
         'cleared_saved': "🗑️ Все сохранённые статьи удалены!",
         'export_empty': "🔖 **Пока нечего экспортировать!**\n\nСначала сохраните статью, затем попробуйте `/export` снова.",
-        'export_caption': "📚 **Экспорт сохранённых статей**\n\nЭкспортировано {count} сохранённых статей в файл Markdown.",
+        'export_caption': "📚 **Экспорт сохранённых статей**\n\nЭкспортировано {count} сохранённых статей.",
         'random_article_header': "🎲 **Случайная статья для вас**\n\n",
         'ai_error': "❌ Не удалось обработать запрос: {error}",
         'refresh_limit': "✅ **Вы узнали всё главное!**\n\nЯ уже сделал для вас 2 уникальных дайджеста. Заходите позже за новыми новостями!",
@@ -235,7 +235,7 @@ Use /sources to toggle sources""",
 🔖 **Сохранённые статьи**
 • /save <ссылка> - Сохранить статью
 • /saved - Просмотреть все сохранённые
-• /export - Экспорт сохранённых статей в Markdown
+• /export [csv] - Экспорт сохранённых статей
 • /filter <категория> - Фильтр по категории (ai, security, crypto, startups, hardware, software, tech)
 • /recap - Недельный обзор сохранённых
 • /clear_saved - Очистить все сохранённые


### PR DESCRIPTION
✨ [add CSV export support for saved articles]

**What:**
Adds the ability to export saved articles in CSV format using the `/export csv` command. It leverages the standard `csv` module to generate a well-formatted CSV with columns for Title, URL, Source, Category, and Saved At timestamp.

**Why:**
While the Markdown export is great for raw text reading, a CSV format is often heavily preferred by users who want to analyze, sort, or store their bookmarks in spreadsheet software (like Excel or Google Sheets). This small feature strongly improves the capability of the bookmarking system.

**Implementation Details:**
- Modified `export_command` in `functions/telegram_bot.py` to check for `csv` or `md` in `context.args`.
- Uses a UTF-8 BOM (`b'\xef\xbb\xbf'`) in the CSV output so it automatically decodes correctly in Microsoft Excel.
- Default behavior without arguments remains Markdown export for 100% backward compatibility.
- Updated English and Russian bot command strings and help text to document the new `[csv]` option.
- Verified test suite passes without regressions.

---
*PR created automatically by Jules for task [6804656732474545416](https://jules.google.com/task/6804656732474545416) started by @AminSS99*