### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP parameter injection in Hacker News lookup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The internal API authentication check `_require_internal_secret` in `functions/main.py` was implemented to fail open if the `INTERNAL_SECRET` environment variable was missing or empty (`if expected and not (...)`).
 **Learning:** Checking for the presence of an expected secret via `if expected` allows the code block to be bypassed if `expected` evaluates to false, making the authorization check fail open and allowing unauthorized access. Also, missing headers would pass `None` to `hmac.compare_digest`, causing a `TypeError`.
 **Prevention:** Always implement authentication and authorization checks using a fail-closed conditional structure (e.g., `if not expected or ...`), ensuring that missing environment variables block access rather than bypassing the check. Also, provide fallback strings when reading headers for cryptographic checks.
+
+## $(date +%Y-%m-%d) - Prevent HTTP Parameter Injection in Hacker News Scraper
+**Vulnerability:** In `find_hn_discussion` (`functions/deep_dive.py`), user-provided URLs were directly interpolated into an API URL string (`f"https://hn.algolia.com/api/v1/search?query={url}&tags=story..."`). This allowed an attacker to input a URL containing `&` characters, injecting unintended query parameters to manipulate the Algolia API request.
+**Learning:** String interpolation for URL parameters does not automatically encode special characters, leading to HTTP Parameter Pollution.
+**Prevention:** Always use the `params` dictionary argument in `httpx.get()` to let the HTTP client safely encode query parameters automatically.

--- a/functions/deep_dive.py
+++ b/functions/deep_dive.py
@@ -99,8 +99,9 @@ async def find_hn_discussion(url: str) -> Optional[Dict[str, Any]]:
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            api_url = f"https://hn.algolia.com/api/v1/search?query={url}&tags=story&hitsPerPage=3"
-            response = await client.get(api_url)
+            api_url = "https://hn.algolia.com/api/v1/search"
+            params = {"query": url, "tags": "story", "hitsPerPage": 3}
+            response = await client.get(api_url, params=params)
             response.raise_for_status()
             data = response.json()
             hits = data.get('hits', [])


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unencoded user-provided URL in `find_hn_discussion` in `functions/deep_dive.py` allowed for HTTP Parameter Injection via Algolia API call.
🎯 **Impact:** An attacker could craft a malicious URL with `&` to overwrite query parameters sent to Algolia, potentially fetching arbitrary data or causing unintended search behavior.
🔧 **Fix:** Refactored the `httpx.get` call to utilize the `params` dictionary argument instead of raw f-string interpolation, ensuring safe automatic URL encoding.
✅ **Verification:** Pytest suite passes cleanly. Syntax verified with py_compile.

---
*PR created automatically by Jules for task [3867672512579952953](https://jules.google.com/task/3867672512579952953) started by @AminSS99*