### PR TITLE
✨ [feature enhancement] Add Read buttons alongside Summarize buttons in article lists

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -725,6 +725,7 @@ async def _render_saved_page(update_or_query, telegram_id: int, user_lang: str, 
         # encode page in callback data so delete button can refresh the correct page
         keyboard.append([
             InlineKeyboardButton(f"🧠 {item_num}", callback_data=f"summarize_url_{url_hash}"),
+            InlineKeyboardButton(f"📖 {item_num}", callback_data=f"read_url_{url_hash}"),
             InlineKeyboardButton(f"{delete_label} {item_num}. {title[:20]}...", callback_data=f"del_{url_hash}_{page}")
         ])
     
@@ -1235,8 +1236,10 @@ async def filter_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if url.startswith('http'):
             url_hash = stable_hash(raw_url)[:8]
             summarize_label = t('btn_summarize', user_lang)
+            read_label = t('btn_read', user_lang)
             keyboard.append([
-                InlineKeyboardButton(f"🧠 {i}. {summarize_label}", callback_data=f"summarize_url_{url_hash}")
+                InlineKeyboardButton(f"🧠 {i}. {summarize_label}", callback_data=f"summarize_url_{url_hash}"),
+                InlineKeyboardButton(f"📖 {i}. {read_label}", callback_data=f"read_url_{url_hash}")
             ])
 
     # Add a back button
@@ -1710,8 +1713,12 @@ async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     url_hash = stable_hash(url)[:8]
 
     summarize_label = t('btn_summarize', user_lang)
+    read_label = t('btn_read', user_lang)
     reply_markup = InlineKeyboardMarkup([
-        [InlineKeyboardButton(summarize_label, callback_data=f"summarize_url_{url_hash}")]
+        [
+            InlineKeyboardButton(summarize_label, callback_data=f"summarize_url_{url_hash}"),
+            InlineKeyboardButton(read_label, callback_data=f"read_url_{url_hash}")
+        ]
     ])
 
     await update.message.reply_text(message, parse_mode='Markdown', reply_markup=reply_markup)


### PR DESCRIPTION
This PR implements a meaningful feature enhancement by introducing an inline "Read" button alongside existing "Summarize" buttons in various commands (`/saved`, `/filter`, `/random`).

Currently, the bot provides a "Summarize" button for items listed via these commands. However, the existing "Read" functionality (`read_url_callback`) was primarily surfaced when manually saving links. Adding the "Read" button to these views provides users immediate options to either read the full parsed text or summarize it, greatly improving usability without bloating the UI or requiring new backend handlers.

### 🎯 What
- Added `InlineKeyboardButton(t('btn_read', user_lang), callback_data=f"read_url_{url_hash}")` to the inline keyboard built in `_render_saved_page` (for `/saved`).
- Added the same button to `filter_command` results list.
- Added the same button to the single result view in `random_command`.

### 💡 Why
This improves the product’s usefulness and capability by giving users a direct path to read articles directly within Telegram from any list or random view, rather than limiting them only to AI summaries or forcing them to open external browsers unnecessarily.

### ✅ Verification
- Ran the full test suite (`pytest test*.py`) which passed successfully.
- Verified that `btn_read` and `read_url_callback` already exist and function properly.

### ✨ Result
Users will now see a `📖 Read` (or localized equivalent) button next to the `🧠 Summarize` button when interacting with saved articles.

---
*PR created automatically by Jules for task [11301398782724165261](https://jules.google.com/task/11301398782724165261) started by @AminSS99*