### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTTP Parameter Pollution in HN search

### DIFF
--- a/functions/deep_dive.py
+++ b/functions/deep_dive.py
@@ -99,8 +99,13 @@ async def find_hn_discussion(url: str) -> Optional[Dict[str, Any]]:
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            api_url = f"https://hn.algolia.com/api/v1/search?query={url}&tags=story&hitsPerPage=3"
-            response = await client.get(api_url)
+            api_url = "https://hn.algolia.com/api/v1/search"
+            params = {
+                "query": url,
+                "tags": "story",
+                "hitsPerPage": 3
+            }
+            response = await client.get(api_url, params=params)
             response.raise_for_status()
             data = response.json()
             hits = data.get('hits', [])


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Hacker News Algolia search function used string interpolation (f-string) to construct the URL with a user-provided `url` variable. If the URL contained ampersands (`&`) or equals (`=`), it could manipulate the query string, resulting in HTTP Parameter Pollution and potentially malformed requests.
🎯 Impact: An attacker could potentially bypass intended search behavior or manipulate the search query sent to the Algolia API.
🔧 Fix: Replaced string interpolation with the `params` argument in `httpx.AsyncClient.get`, allowing `httpx` to safely and securely URL-encode the parameters.
✅ Verification: Ran the existing test suite, which continues to pass, ensuring the change introduces no regressions.

---
*PR created automatically by Jules for task [3298374159884834956](https://jules.google.com/task/3298374159884834956) started by @AminSS99*