### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP Parameter Pollution in deep_dive.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** The internal API authentication check `_require_internal_secret` in `functions/main.py` was implemented to fail open if the `INTERNAL_SECRET` environment variable was missing or empty (`if expected and not (...)`).
 **Learning:** Checking for the presence of an expected secret via `if expected` allows the code block to be bypassed if `expected` evaluates to false, making the authorization check fail open and allowing unauthorized access. Also, missing headers would pass `None` to `hmac.compare_digest`, causing a `TypeError`.
 **Prevention:** Always implement authentication and authorization checks using a fail-closed conditional structure (e.g., `if not expected or ...`), ensuring that missing environment variables block access rather than bypassing the check. Also, provide fallback strings when reading headers for cryptographic checks.
+
+## 2024-06-05 - [HIGH] Prevent HTTP Parameter Pollution via F-string URL Construction
+**Vulnerability:** The Algolia HN API URL in `functions/deep_dive.py` was built using f-string string interpolation: `api_url = f"https://hn.algolia.com/api/v1/search?query={url}&tags=story&hitsPerPage=3"`. This allowed for HTTP Parameter Pollution or manipulation if the `url` variable contained special URL characters (e.g., `&`, `=`, `#`).
+**Learning:** Constructing HTTP queries with basic string formatting is prone to injection flaws and URL malformation because variables are not safely URL-encoded before being appended.
+**Prevention:** Always use the dedicated `params` dictionary argument provided by modern HTTP clients (like `httpx.get(url, params=...)` or `requests.get(url, params=...)`) to ensure all user input or variable data is automatically and safely URL-encoded prior to transmission.

--- a/functions/deep_dive.py
+++ b/functions/deep_dive.py
@@ -99,8 +99,13 @@ async def find_hn_discussion(url: str) -> Optional[Dict[str, Any]]:
 
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            api_url = f"https://hn.algolia.com/api/v1/search?query={url}&tags=story&hitsPerPage=3"
-            response = await client.get(api_url)
+            api_url = "https://hn.algolia.com/api/v1/search"
+            params = {
+                "query": url,
+                "tags": "story",
+                "hitsPerPage": 3
+            }
+            response = await client.get(api_url, params=params)
             response.raise_for_status()
             data = response.json()
             hits = data.get('hits', [])


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Algolia API query URL in `functions/deep_dive.py` was being built using an f-string to inject the raw `url` variable. This meant if the `url` had URL-breaking characters (like spaces, `&`, `=`), it could cause HTTP Parameter Pollution, altering the original intent of the backend API call or resulting in a malformed request error.
🎯 **Impact:** Attackers could alter query parameters or inject arbitrary keys to the Algolia request, or cause the server to perform malformed requests.
🔧 **Fix:** Refactored the `httpx.get` call to utilize the `params` dictionary parameter. This securely delegates URL encoding to the HTTP client to ensure no raw injection happens in the query string.
✅ **Verification:** Verified by running `pytest` (25 tests passed) and obtaining a successful code review. Also added an entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7863838278098047070](https://jules.google.com/task/7863838278098047070) started by @AminSS99*