### PR TITLE
✨ Feature: Export Buttons in Saved and Stats Views

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -761,9 +761,13 @@ async def _render_saved_page(update_or_query, telegram_id: int, user_lang: str, 
     if nav_buttons:
         keyboard.append(nav_buttons)
 
-    # Add Clear All button
+    # Add Export and Clear All buttons
     clear_all_text = t('clear_all_btn', user_lang)
-    keyboard.append([InlineKeyboardButton(clear_all_text, callback_data=f"clear_all_prompt_{page}")])
+    export_text = t('export_btn', user_lang)
+    keyboard.append([
+        InlineKeyboardButton(export_text, callback_data="do_export_prompt_all"),
+        InlineKeyboardButton(clear_all_text, callback_data=f"clear_all_prompt_{page}")
+    ])
 
     reply_markup = InlineKeyboardMarkup(keyboard) if keyboard else None
     
@@ -923,7 +927,7 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         return
 
     # If format not specified, show inline keyboard to select
-    if not export_format:
+    if not export_format or export_format == 'prompt':
         keyboard = [
             [
                 InlineKeyboardButton("📄 Markdown (.md)", callback_data=f"do_export_md_{category_filter or 'all'}"),
@@ -1695,7 +1699,10 @@ async def stats_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         for source, count in sources.most_common(5):
             message += f"• {source}: {count}\n"
 
-    await update.message.reply_text(message, parse_mode='Markdown')
+    export_text = t('export_btn', user_lang)
+    reply_markup = InlineKeyboardMarkup([[InlineKeyboardButton(export_text, callback_data="do_export_prompt_all")]])
+
+    await update.message.reply_text(message, parse_mode='Markdown', reply_markup=reply_markup)
 
 # ============ ADMIN STATUS ============
 

--- a/functions/translations.py
+++ b/functions/translations.py
@@ -132,6 +132,7 @@ Use /sources to toggle sources""",
         'clear_all_prompt': "⚠️ **Are you sure you want to delete ALL saved articles?**\n\nThis action cannot be undone.",
         'clear_all_confirm_btn': "✅ Yes, delete all",
         'clear_all_cancel_btn': "❌ Cancel",
+        'export_btn': "📤 Export",
         
         # Stats
         'stats_empty': "📊 *Reading Statistics*\n\nYou haven't saved any articles yet! Save articles to see your reading stats.",
@@ -309,6 +310,7 @@ _Работает локально - настройки сохранятся п�
         'clear_all_prompt': "⚠️ **Вы уверены, что хотите удалить ВСЕ сохранённые статьи?**\n\nЭто действие нельзя отменить.",
         'clear_all_confirm_btn': "✅ Да, удалить всё",
         'clear_all_cancel_btn': "❌ Отмена",
+        'export_btn': "📤 Экспорт",
         
         # Stats
         'stats_empty': "📊 *Статистика чтения*\n\nВы еще не сохранили ни одной статьи! Сохраняйте статьи, чтобы увидеть свою статистику.",


### PR DESCRIPTION
This PR implements a meaningful UX improvement by surfacing the Export feature directly within the `/saved` and `/stats` views. 

Users can now natively export their saved articles to Markdown or CSV directly from the interfaces where they are viewing their statistics or managing their saved lists, making the feature significantly more discoverable.

**What was changed:**
1. Added the necessary `export_btn` translations in `functions/translations.py`.
2. Modified the `_do_export` handler in `functions/telegram_bot.py` to trigger the format prompt when requested via an inline button callback.
3. Added the Export button in the `_render_saved_page` alongside the Clear All button.
4. Added the Export button to the bottom of the `stats_command` output.

---
*PR created automatically by Jules for task [5561549300844889419](https://jules.google.com/task/5561549300844889419) started by @AminSS99*