### PR TITLE
✨ Add Delete button to random article view

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1634,14 +1634,16 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     user_lang = get_user_language(telegram_id)
     
     # Get the URL hash and page from callback data
-    data = query.data  # e.g., "del_abc12345_0"
+    data = query.data  # e.g., "del_abc12345_0" or "del_abc12345_random"
     parts = data.split('_')
     if len(parts) >= 2:
         url_hash = parts[1]
     else:
         url_hash = data.replace('del_', '')
 
-    page = int(parts[2]) if len(parts) > 2 else 0
+    page = parts[2] if len(parts) > 2 else 0
+    if isinstance(page, str) and page.isdigit():
+        page = int(page)
     
     # Find the article with matching hash
     from .security_utils import stable_hash
@@ -1660,8 +1662,14 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     else:
         await query.answer("Article deleted!", show_alert=False)
 
-    # Refresh the current page
-    await _render_saved_page(query, telegram_id, user_lang, page, is_callback=True)
+    # Conditionally handle the response rendering
+    if page == 'random':
+        # Refresh with a new random article by deleting the old message and calling random_command
+        await query.message.delete()
+        await random_command(update, context)
+    else:
+        # Refresh the current page
+        await _render_saved_page(query, telegram_id, user_lang, page, is_callback=True)
 
 
 
@@ -1762,6 +1770,9 @@ async def random_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             InlineKeyboardButton(read_label, callback_data=f"read_url_{url_hash}"),
             InlineKeyboardButton(summarize_label, callback_data=f"summarize_url_{url_hash}"),
             InlineKeyboardButton("↗️", url=f"https://t.me/share/url?url={urllib.parse.quote(url)}&text={urllib.parse.quote(title)}")
+        ],
+        [
+            InlineKeyboardButton("🗑️ Delete", callback_data=f"del_{url_hash}_random")
         ]
     ])
 


### PR DESCRIPTION
This PR implements a meaningful feature enhancement by adding a "Delete" button to the inline keyboard of the `/random` command in the Telegram bot.

Previously, if a user viewed a random article and wanted to delete it from their saved list, they would have to exit the view, open their saved list, find the article, and delete it there. Now, they can delete it directly from the random view. Furthermore, clicking the delete button in this context will automatically serve up the next random article, creating a seamless "swipe/skip" style reading experience.

The implementation gracefully parses the "random" keyword in the pagination parameter of the `delete_article_callback` to achieve this routing safely.

---
*PR created automatically by Jules for task [8089390901804171996](https://jules.google.com/task/8089390901804171996) started by @AminSS99*