### PR TITLE
✨ [Feature] Add reply context to AI chat and improve URL regex detection

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -2605,8 +2605,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # The big persistent keyboard has been disabled, so these checks are no longer needed.
     # Users should use the /slash commands from the menu.
     
+    import re
     # Check if it's a URL to save
-    if user_message.startswith('http://') or user_message.startswith('https://'):
+    if re.match(r'^https?://[^\s]+$', user_message):
         from .user_storage import save_article, save_temp_url
         from .security_utils import stable_hash, is_safe_url
         import httpx
@@ -2678,6 +2679,13 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(t('rate_limited', user_lang, seconds='60'))
         return
     
+    reply_context = ""
+    if update.message.reply_to_message:
+        reply_context = update.message.reply_to_message.text or update.message.reply_to_message.caption or ""
+
+    if reply_context:
+        user_message = f"Context from replied message: {reply_context}\n\nUser Question: {user_message}"
+
     chat_id = update.effective_chat.id
     await context.bot.send_chat_action(chat_id=chat_id, action=constants.ChatAction.TYPING)
     


### PR DESCRIPTION
✨ **What** (The feature improvement)
Implemented two meaningful enhancements to the bot's messaging handler (`handle_message`):
1. **Context-Aware AI Chat:** The bot now extracts context from a replied message (`reply_to_message.text` or `caption`) and passes it into the LLM prompt. Users can now reply to an article in their digest with "What does this mean?" and the AI will answer accurately.
2. **Robust URL Detection:** The bot previously used `.startswith('http')` to intercept links for saving. This blocked users from asking questions that happened to start with a URL (e.g., "https://example.com is broken, what does a 502 mean?"). This has been fixed by replacing the logic with a strict regex matching only complete standalone URLs (`^https?://[^\s]+$`).

💡 **Why** (How it improves capability)
- **Context:** Without reply context, the conversational AI feature lacks continuity, heavily restricting its usefulness for deep dives into specific news articles.
- **Regex Fix:** The broad URL detection was an aggressive interception that broke expected bot behavior (AI Q&A) for valid inputs. 

✅ **Verification**
- Checked test suite passes successfully.
- Code review approved without regressions.

---
*PR created automatically by Jules for task [14912039602410219096](https://jules.google.com/task/14912039602410219096) started by @AminSS99*