### PR TITLE
✨ Add HTML Netscape Bookmark export format

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -912,6 +912,7 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
     from .user_storage import get_all_saved_articles
     import io
     import csv
+    import html
 
     def _clean_export_value(value) -> str:
         if value is None:
@@ -932,11 +933,14 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
             [
                 InlineKeyboardButton("📄 Markdown (.md)", callback_data=f"do_export_md_{category_filter or 'all'}"),
                 InlineKeyboardButton("📊 Excel (.csv)", callback_data=f"do_export_csv_{category_filter or 'all'}")
+            ],
+            [
+                InlineKeyboardButton("🌐 Bookmarks (.html)", callback_data=f"do_export_html_{category_filter or 'all'}")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await message_obj.reply_text(
-            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.",
+            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.\n_Bookmarks_ can be imported into your browser.",
             parse_mode='Markdown',
             reply_markup=reply_markup
         )
@@ -963,6 +967,35 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         # Write UTF-8 BOM so Excel opens it correctly
         document = io.BytesIO(b'\xef\xbb\xbf' + output.getvalue().encode('utf-8'))
         document.name = f"lensai_saved_articles{filename_category}_{timestamp}.csv"
+    elif export_format == 'html':
+        # HTML Netscape Bookmark format
+        lines = [
+            "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+            "<!-- This is an automatically generated file.",
+            "     It will be read and overwritten.",
+            "     DO NOT EDIT! -->",
+            "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=UTF-8\">",
+            "<TITLE>Bookmarks</TITLE>",
+            "<H1>Bookmarks</H1>",
+            "<DL><p>"
+        ]
+
+        for article in articles:
+            title = _clean_export_value(article.get('title')) or "Untitled"
+            url = _clean_export_value(article.get('url'))
+            saved_at = _clean_export_value(article.get('saved_at'))
+
+            # Netscape bookmark format uses ADD_DATE for unix timestamps,
+            # but we just keep it simple
+            safe_url = html.escape(url) if url else ""
+            safe_title = html.escape(title)
+
+            lines.append(f'    <DT><A HREF="{safe_url}">{safe_title}</A>')
+
+        lines.append("</DL><p>")
+
+        document = io.BytesIO("\n".join(lines).encode('utf-8'))
+        document.name = f"lensai_saved_articles{filename_category}_{timestamp}.html"
     else:
         # Markdown export
         lines = [
@@ -1020,6 +1053,8 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             export_format = 'md'
         elif arg_lower in ['csv', 'excel']:
             export_format = 'csv'
+        elif arg_lower in ['html', 'bookmarks']:
+            export_format = 'html'
         else:
             category_filter = arg_lower
 


### PR DESCRIPTION
This PR implements a new feature allowing users to export their saved articles in the standard Netscape Bookmark (`.html`) format.

### 🌟 Feature
Added a new export option allowing users to directly download their saved articles as an HTML file compatible with all major web browsers.

### 🛠️ Changes
- Updated the `/export` command to accept `html` or `bookmarks` arguments.
- Added a new button to the interactive inline keyboard for format selection.
- Implemented generation of the `<!DOCTYPE NETSCAPE-Bookmark-file-1>` formatted file.
- Used `html.escape` to safely include user-provided titles and URLs in the HTML document.
- Maintained existing export functionality (Markdown and CSV) without disruption.

### ✅ Verification
- Tested the inline keyboard manually.
- Verified standard argument parsing (`/export html`).
- Ran all existing `pytest` tests successfully.
- Code review performed to ensure correctness and safety.

---
*PR created automatically by Jules for task [6297139319431372838](https://jules.google.com/task/6297139319431372838) started by @AminSS99*