### PR TITLE
✨ Add HTML Bookmark export for saved articles

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -932,11 +932,14 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
             [
                 InlineKeyboardButton("📄 Markdown (.md)", callback_data=f"do_export_md_{category_filter or 'all'}"),
                 InlineKeyboardButton("📊 Excel (.csv)", callback_data=f"do_export_csv_{category_filter or 'all'}")
+            ],
+            [
+                InlineKeyboardButton("🌐 HTML Bookmark (.html)", callback_data=f"do_export_html_{category_filter or 'all'}")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await message_obj.reply_text(
-            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.",
+            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.\n_HTML_ is great for importing directly into your web browser's bookmarks.",
             parse_mode='Markdown',
             reply_markup=reply_markup
         )
@@ -963,6 +966,32 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         # Write UTF-8 BOM so Excel opens it correctly
         document = io.BytesIO(b'\xef\xbb\xbf' + output.getvalue().encode('utf-8'))
         document.name = f"lensai_saved_articles{filename_category}_{timestamp}.csv"
+    elif export_format == 'html':
+        import html
+        lines = [
+            "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+            "<!-- This is an automatically generated bookmark list. -->",
+            "<TITLE>LensAI Saved Articles</TITLE>",
+            "<H1>LensAI Saved Articles</H1>",
+            "<DL><p>"
+        ]
+
+        for article in articles:
+            title = _clean_export_value(article.get('title')) or "Untitled"
+            url = _clean_export_value(article.get('url'))
+
+            if not url:
+                continue
+
+            safe_title = html.escape(title)
+            safe_url = html.escape(url)
+
+            lines.append(f'    <DT><A HREF="{safe_url}">{safe_title}</A>')
+
+        lines.append("</DL><p>")
+
+        document = io.BytesIO("\n".join(lines).encode('utf-8'))
+        document.name = f"lensai_saved_articles{filename_category}_{timestamp}.html"
     else:
         # Markdown export
         lines = [
@@ -1020,6 +1049,8 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             export_format = 'md'
         elif arg_lower in ['csv', 'excel']:
             export_format = 'csv'
+        elif arg_lower in ['html', 'bookmark', 'bookmarks']:
+            export_format = 'html'
         else:
             category_filter = arg_lower
 


### PR DESCRIPTION
🎯 **What**
Added a feature that allows users to export their saved articles as an HTML Netscape Bookmark file. 

💡 **Why**
While CSV and Markdown exports are good for data archival and notes, users lacked an easy way to move their reading list into a browser. Generating a standard Netscape Bookmark file fulfills this common user desire with a progressive enhancement that seamlessly fits into the current architecture. This answers the requirement: "Oh wow, that should have always been there."

✅ **Verification**
- Added UI prompts and parsing for `html`.
- Implemented file generation with proper HTML escaping using `html.escape()`.
- Successfully ran the test suite (`python -m pytest test*.py`) showing 25/25 passing to ensure no regressions were introduced to the scraper or security modules.
- Request passed code review and validation checks.

---
*PR created automatically by Jules for task [13828677173835654917](https://jules.google.com/task/13828677173835654917) started by @AminSS99*