### PR TITLE
✨ Add interactive action buttons to `/recap` articles

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1333,7 +1333,13 @@ async def recap_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     message = t('recap_header', user_lang)
     
     # Show top 5 recent articles
-    from .security_utils import sanitize_markdown_url
+    from .security_utils import sanitize_markdown_url, stable_hash
+    from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+    keyboard = []
+
+    summarize_label = t('btn_summarize', user_lang)
+    read_label = t('btn_read', user_lang)
+
     for i, article in enumerate(weekly_articles[:5], 1):
         title = article.get('title', 'Untitled')[:50]
         url = sanitize_markdown_url(article.get('url', ''))
@@ -1344,13 +1350,22 @@ async def recap_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             message += f"{i}. {emoji} [{title}]({url})\n"
         else:
             message += f"{i}. {emoji} {title}\n"
+
+        if url.startswith('http'):
+            url_hash = stable_hash(article.get('url', ''))[:8]
+            keyboard.append([
+                InlineKeyboardButton(f"📖 {i}. {read_label}", callback_data=f"read_url_{url_hash}"),
+                InlineKeyboardButton(f"🧠 {i}. {summarize_label}", callback_data=f"summarize_url_{url_hash}")
+            ])
+
+    reply_markup = InlineKeyboardMarkup(keyboard) if keyboard else None
     
     message += f"\n_Total: {len(weekly_articles)} articles this week_"
     
     try:
-        await update.message.reply_text(message, parse_mode='Markdown', disable_web_page_preview=True)
+        await update.message.reply_text(message, parse_mode='Markdown', disable_web_page_preview=True, reply_markup=reply_markup)
     except Exception:
-        await update.message.reply_text(message, disable_web_page_preview=True)
+        await update.message.reply_text(message, disable_web_page_preview=True, reply_markup=reply_markup)
 
 
 async def share_command(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
**What**
Enhanced the `/recap` command by adding interactive inline buttons ('Read' and 'Summarize') to each of the top 5 weekly articles listed in the response.

**Why**
Previously, the `/recap` command only listed the top 5 articles from the past week as static text links. Users could click the links to open them externally, but couldn't use the bot's core features (like reading inline or summarizing via AI) directly from the recap list without manually finding those URLs again in `/saved`. This makes the weekly recap immediately useful and actionable.

**Verification**
- Modified `recap_command` in `functions/telegram_bot.py`.
- Added logic to generate `url_hash` using `stable_hash`.
- Integrated `InlineKeyboardButton` components with `read_url_` and `summarize_url_` callback hooks.
- Tested changes by running the test suite (`pytest`), with all 25 tests passing.
- Requested and passed code review ensuring no regressions (such as N+1 issues) were introduced.

---
*PR created automatically by Jules for task [1405070073643797316](https://jules.google.com/task/1405070073643797316) started by @AminSS99*