### PR TITLE
✨ Feature: Add HTML Bookmark Export

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -931,12 +931,13 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         keyboard = [
             [
                 InlineKeyboardButton("📄 Markdown (.md)", callback_data=f"do_export_md_{category_filter or 'all'}"),
-                InlineKeyboardButton("📊 Excel (.csv)", callback_data=f"do_export_csv_{category_filter or 'all'}")
+                InlineKeyboardButton("📊 Excel (.csv)", callback_data=f"do_export_csv_{category_filter or 'all'}"),
+                InlineKeyboardButton("🔖 Bookmarks (.html)", callback_data=f"do_export_html_{category_filter or 'all'}")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await message_obj.reply_text(
-            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.",
+            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.\n_Bookmarks_ can be imported into your browser.",
             parse_mode='Markdown',
             reply_markup=reply_markup
         )
@@ -963,6 +964,42 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         # Write UTF-8 BOM so Excel opens it correctly
         document = io.BytesIO(b'\xef\xbb\xbf' + output.getvalue().encode('utf-8'))
         document.name = f"lensai_saved_articles{filename_category}_{timestamp}.csv"
+    elif export_format == 'html':
+        import html
+        lines = [
+            "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+            "<!-- This is an automatically generated bookmark list. -->",
+            "<!-- It will be read and overwritten. -->",
+            "<!-- DO NOT EDIT! -->",
+            "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=UTF-8\">",
+            "<TITLE>Bookmarks</TITLE>",
+            "<H1>Bookmarks</H1>",
+            "<DL><p>"
+        ]
+
+        for article in articles:
+            title = _clean_export_value(article.get('title')) or "Untitled"
+            url = _clean_export_value(article.get('url'))
+            saved_at = _clean_export_value(article.get('saved_at'))
+
+            # Use current time if no saved_at, convert to unix timestamp
+            try:
+                if saved_at:
+                    add_date = int(datetime.fromisoformat(saved_at.replace('Z', '+00:00')).timestamp())
+                else:
+                    add_date = int(datetime.now(timezone.utc).timestamp())
+            except Exception:
+                add_date = int(datetime.now(timezone.utc).timestamp())
+
+            safe_url = html.escape(url)
+            safe_title = html.escape(title)
+
+            if safe_url:
+                lines.append(f"    <DT><A HREF=\"{safe_url}\" ADD_DATE=\"{add_date}\">{safe_title}</A>")
+
+        lines.append("</DL><p>")
+        document = io.BytesIO("\n".join(lines).encode('utf-8'))
+        document.name = f"lensai_saved_articles{filename_category}_{timestamp}.html"
     else:
         # Markdown export
         lines = [
@@ -1020,6 +1057,8 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             export_format = 'md'
         elif arg_lower in ['csv', 'excel']:
             export_format = 'csv'
+        elif arg_lower in ['html', 'bookmarks']:
+            export_format = 'html'
         else:
             category_filter = arg_lower
 


### PR DESCRIPTION
This PR adds a new export format to the bot: HTML Netscape Bookmarks.

**Changes:**
- Added `Bookmarks (.html)` option to the inline keyboard in `_do_export`.
- Added generation of `<!DOCTYPE NETSCAPE-Bookmark-file-1>` formatted files in `_do_export`.
- Used `html.escape` to safely escape titles and URLs to prevent injection.
- Updated `export_command` to accept `html` and `bookmarks` as arguments for CLI export.

**Testing:**
- Verified no syntax errors were introduced.
- Ran all existing `pytest` tests which passed successfully.

---
*PR created automatically by Jules for task [15467611563325671960](https://jules.google.com/task/15467611563325671960) started by @AminSS99*