### PR TITLE
✨ feat: Support exporting saved articles to HTML Browser Bookmarks

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -912,6 +912,7 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
     from .user_storage import get_all_saved_articles
     import io
     import csv
+    import html
 
     def _clean_export_value(value) -> str:
         if value is None:
@@ -932,11 +933,14 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
             [
                 InlineKeyboardButton("📄 Markdown (.md)", callback_data=f"do_export_md_{category_filter or 'all'}"),
                 InlineKeyboardButton("📊 Excel (.csv)", callback_data=f"do_export_csv_{category_filter or 'all'}")
+            ],
+            [
+                InlineKeyboardButton("🔖 Browser Bookmarks (.html)", callback_data=f"do_export_html_{category_filter or 'all'}")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await message_obj.reply_text(
-            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.",
+            "📦 *Choose export format:*\n\n_Markdown_ is great for notes like Obsidian or Notion.\n_Excel_ is great for spreadsheets.\n_Bookmarks_ can be imported into browsers.",
             parse_mode='Markdown',
             reply_markup=reply_markup
         )
@@ -963,6 +967,25 @@ async def _do_export(message_obj, telegram_id: int, user_lang: str, export_forma
         # Write UTF-8 BOM so Excel opens it correctly
         document = io.BytesIO(b'\xef\xbb\xbf' + output.getvalue().encode('utf-8'))
         document.name = f"lensai_saved_articles{filename_category}_{timestamp}.csv"
+    elif export_format == 'html':
+        # Browser Bookmark Export
+        lines = [
+            "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+            '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">',
+            "<TITLE>Bookmarks</TITLE>",
+            "<H1>LensAI Bookmarks</H1>",
+            "<DL><p>"
+        ]
+
+        for article in articles:
+            title = html.escape(_clean_export_value(article.get('title')) or "Untitled")
+            url = html.escape(_clean_export_value(article.get('url')) or "")
+            lines.append(f'    <DT><A HREF="{url}">{title}</A>')
+
+        lines.append("</DL><p>")
+
+        document = io.BytesIO("\n".join(lines).encode('utf-8'))
+        document.name = f"lensai_bookmarks{filename_category}_{timestamp}.html"
     else:
         # Markdown export
         lines = [
@@ -1020,6 +1043,8 @@ async def export_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
             export_format = 'md'
         elif arg_lower in ['csv', 'excel']:
             export_format = 'csv'
+        elif arg_lower in ['html', 'bookmarks', 'bookmark']:
+            export_format = 'html'
         else:
             category_filter = arg_lower
 


### PR DESCRIPTION
**What**
Added support for exporting saved articles as a Netscape Bookmark HTML file. This allows users to natively import their saved reading list into modern web browsers (Chrome, Firefox, Safari, Edge).

**Why**
Exporting to Markdown and CSV is useful, but the primary use case for saved links is typically reading them in a web browser. By providing a native Netscape Bookmark formatted file, users can import their entire saved collection into a native browser folder structure in just a few clicks.

**Verification**
- Created a test bookmark HTML file using the new formatting to verify correct tags (`<!DOCTYPE NETSCAPE-Bookmark-file-1>`).
- Ensured `html.escape()` is used on all user-controlled data (URLs, titles) to prevent broken HTML generation.
- Validated modifications to the `export_command` and `_do_export` handler flows.
- Executed the full project test suite (`pytest`), achieving a 100% pass rate.

---
*PR created automatically by Jules for task [5862434428206290608](https://jules.google.com/task/5862434428206290608) started by @AminSS99*