### PR TITLE
✨ Add inline delete button to article reading views

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1697,10 +1697,13 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
         url_hash = data.replace('del_', '')
 
     is_random = False
+    is_inline = False
     page = 0
     if len(parts) > 2:
         if parts[2] == 'random':
             is_random = True
+        elif parts[2] == 'inline':
+            is_inline = True
         elif parts[2].isdigit():
             page = int(parts[2])
     
@@ -1725,6 +1728,15 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     if is_random:
         await query.message.delete()
         await random_command(update, context)
+    elif is_inline:
+        current_markup = query.message.reply_markup
+        if current_markup and current_markup.inline_keyboard:
+            new_keyboard = []
+            for row in current_markup.inline_keyboard:
+                new_row = [btn for btn in row if not (btn.callback_data and btn.callback_data.startswith('del_'))]
+                if new_row:
+                    new_keyboard.append(new_row)
+            await query.message.edit_reply_markup(reply_markup=InlineKeyboardMarkup(new_keyboard))
     else:
         await _render_saved_page(query, telegram_id, user_lang, page, is_callback=True)
 
@@ -2494,7 +2506,8 @@ async def summarize_url_callback(update: Update, context: ContextTypes.DEFAULT_T
             [
                 InlineKeyboardButton("🌐 Original", url=url),
                 InlineKeyboardButton("📖 Read", callback_data=f"read_url_{url_hash}"),
-                InlineKeyboardButton("↗️ Share", url=share_url)
+                InlineKeyboardButton("↗️ Share", url=share_url),
+                InlineKeyboardButton("🗑️ Delete", callback_data=f"del_{url_hash}_inline")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
@@ -2613,7 +2626,8 @@ async def read_url_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
             [
                 InlineKeyboardButton("🌐 Original", url=url),
                 InlineKeyboardButton("🧠 Summarize", callback_data=f"summarize_url_{url_hash}"),
-                InlineKeyboardButton("↗️ Share", url=share_url)
+                InlineKeyboardButton("↗️ Share", url=share_url),
+                InlineKeyboardButton("🗑️ Delete", callback_data=f"del_{url_hash}_inline")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)


### PR DESCRIPTION
This pull request introduces a highly practical workflow enhancement by adding a "Delete" button directly to the inline keyboard of the "Read" and "Summarize" article views.

Users can now immediately delete an article from their saved list right after consuming it, saving them from navigating back to the main saved articles list. To ensure a smooth user experience, deleting an article from these views does not reload the main saved list; instead, it dynamically updates the current message's keyboard to remove the delete button, providing immediate, non-intrusive feedback without disrupting the reading experience.

---
*PR created automatically by Jules for task [15695046558584146029](https://jules.google.com/task/15695046558584146029) started by @AminSS99*