### PR TITLE
✨ Add "Unsave" button to article reading view

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1697,10 +1697,13 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
         url_hash = data.replace('del_', '')
 
     is_random = False
+    is_read = False
     page = 0
     if len(parts) > 2:
         if parts[2] == 'random':
             is_random = True
+        elif parts[2] == 'read':
+            is_read = True
         elif parts[2].isdigit():
             page = int(parts[2])
     
@@ -1725,6 +1728,8 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     if is_random:
         await query.message.delete()
         await random_command(update, context)
+    elif is_read:
+        await query.edit_message_reply_markup(reply_markup=None)
     else:
         await _render_saved_page(query, telegram_id, user_lang, page, is_callback=True)
 
@@ -2614,6 +2619,9 @@ async def read_url_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 InlineKeyboardButton("🌐 Original", url=url),
                 InlineKeyboardButton("🧠 Summarize", callback_data=f"summarize_url_{url_hash}"),
                 InlineKeyboardButton("↗️ Share", url=share_url)
+            ],
+            [
+                InlineKeyboardButton("🗑️ Unsave", callback_data=f"del_{url_hash}_read")
             ]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)

--- a/plan.md
+++ b/plan.md
@@ -1,11 +1,12 @@
-1. **Goal**: Introduce a "Summarize" inline button for saved articles so users can quickly generate AI summaries of specific URLs without manually sending the link or re-copying it.
-2. **Where to Add Summarize Buttons**:
-   - `saved_command`: Currently paginates and shows inline "Delete 🗑️" buttons. We will add a "Summarize 🧠" inline button alongside each "Delete 🗑️" button.
-   - `random_command`: Currently shows a random article with no reply markup. We will add a "Summarize 🧠" inline button.
-   - `filter_command`: Currently lists filtered articles. We will add "Summarize 🧠" buttons for the first few items or attach a generic keyboard for the listed items.
-   - `search_command`: Currently lists search results. We will attach summarize buttons here too if applicable, or we'll stick to just saved items as per "Summarize saved URL". The feature description implies making "Summarize" easily accessible where articles are listed. The `/random` and `/saved` commands are perfect places.
-3. **Existing Infrastructure**: The `summarize_url_<hash>` callback handler is already implemented (`summarize_url_callback`). We just need to add the buttons that trigger it.
-4. **Execution**:
-   - Update `_render_saved_page` in `functions/telegram_bot.py` to include a summarize button before the delete button in the inline keyboard array.
-   - Update `random_command` in `functions/telegram_bot.py` to add a reply markup containing a summarize button for the chosen article.
-   - Run tests and `pre_commit_instructions` to ensure safety and functionality.
+1. **Goal**: Add a "🗑️ Unsave" button to the article reading view (`read_url_callback`) so users can remove an article after reading it.
+2. **Implementation details**:
+   - In `functions/telegram_bot.py`, `read_url_callback` renders chunks of text. The last chunk gets a `reply_markup` with "Original", "Summarize", and "Share".
+   - We will add "🗑️ Unsave" with `callback_data=f"del_{url_hash}_read"`.
+   - Update `delete_article_callback` to handle the `read` flag (like it handles `random`). When `is_read = True`, it will delete the article, answer the query, and delete the message without needing to call a command to re-render. Since `read_url_callback` splits messages, deleting the last message chunk is sufficient (or simply editing the last chunk's reply markup to remove the buttons, with an "Article deleted" notification). Wait, editing the buttons to remove them might be cleaner. Let's just edit the message reply markup.
+3. **Plan steps**:
+   1. Use `replace_with_git_merge_diff` to add the "Unsave" button in `read_url_callback`.
+   2. Use `replace_with_git_merge_diff` to update `delete_article_callback` to handle `read` context.
+   3. Verify changes using `grep` or `cat`.
+   4. Run tests with `python -m pytest test*.py`.
+   5. Complete pre commit steps to ensure proper testing, verification, review, and reflection are done.
+   6. Submit the change.


### PR DESCRIPTION
🎯 **What:**
Introduced a "🗑️ Unsave" button to the inline article reading view.

💡 **Why:**
Improves user experience by supporting the common "read and delete" workflow. Users no longer need to navigate back to the paginated `/saved` list to delete an article they just finished reading.

✅ **Verification:**
- Verified button rendering in `read_url_callback`.
- Verified `delete_article_callback` correctly handles the `is_read` flag and safely removes the reply markup upon completion.
- All 25 unit tests continue to pass.

✨ **Result:**
Users can now delete articles with a single tap immediately after reading them, keeping their saved lists clean.

---
*PR created automatically by Jules for task [12171015666368895376](https://jules.google.com/task/12171015666368895376) started by @AminSS99*