### PR TITLE
✨ Feature: Quick Action Inline Buttons for `/save` Command

### DIFF
--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -895,7 +895,27 @@ async def save_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if save_article(telegram_id, title, url_to_save, category=category):
         cat_label = t(f'cat_{category}', user_lang)
-        await update.message.reply_text(t('article_saved_single', user_lang, category=cat_label))
+
+        from .security_utils import stable_hash
+        from .user_storage import save_temp_url
+        url_hash = stable_hash(url_to_save)[:8]
+        save_temp_url(url_hash, telegram_id, url_to_save)
+
+        read_label = t('btn_read', user_lang)
+        summarize_label = t('btn_summarize', user_lang)
+        del_label = "🗑️ " + ("Удалить" if user_lang == 'ru' else "Delete")
+        reply_markup = InlineKeyboardMarkup([
+            [
+                InlineKeyboardButton(f"📖 {read_label}", callback_data=f"read_url_{url_hash}"),
+                InlineKeyboardButton(f"🧠 {summarize_label}", callback_data=f"summarize_url_{url_hash}")
+            ],
+            [
+                InlineKeyboardButton(del_label, callback_data=f"del_{url_hash}_single")
+            ]
+        ])
+
+        await update.message.reply_text(t('article_saved_single', user_lang, category=cat_label), reply_markup=reply_markup)
+
         try:
             from .deep_dive import queue_deep_dive
             queue_deep_dive(telegram_id, article_data)
@@ -1697,10 +1717,13 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
         url_hash = data.replace('del_', '')
 
     is_random = False
+    is_single = False
     page = 0
     if len(parts) > 2:
         if parts[2] == 'random':
             is_random = True
+        elif parts[2] == 'single':
+            is_single = True
         elif parts[2].isdigit():
             page = int(parts[2])
     
@@ -1725,6 +1748,9 @@ async def delete_article_callback(update: Update, context: ContextTypes.DEFAULT_
     if is_random:
         await query.message.delete()
         await random_command(update, context)
+    elif is_single:
+        msg = "🗑️ " + t('article_deleted', user_lang)
+        await query.message.edit_text(msg, reply_markup=None)
     else:
         await _render_saved_page(query, telegram_id, user_lang, page, is_callback=True)
 


### PR DESCRIPTION
This PR implements a meaningful enhancement to the `/save` flow:
- After a user saves an article via the `/save` command, they now receive a quick-action inline keyboard immediately attached to the confirmation message.
- The keyboard provides direct access to the existing features: **Read**, **Summarize**, and **Delete**.
- To support this seamlessly, the `delete_article_callback` handler was updated to process `del_..._single` requests, replacing the inline buttons with a confirmation message upon deletion without causing an unwanted redirect to the generic `/saved` list view.

The feature is lightweight, fully utilizes the existing infrastructure, requires zero architectural changes, and directly boosts product usability.

---
*PR created automatically by Jules for task [7611602548965432532](https://jules.google.com/task/7611602548965432532) started by @AminSS99*