### PR TITLE
🛡️ Sentinel: [HIGH] Fix Markdown injection in bot commands

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Vulnerability:** The function `extract_github_repo` in `functions/deep_dive.py` used a permissive regular expression `r'github\.com/([^/]+/[^/]+)'` to extract the repository path. This allowed URL-encoded path traversal payloads (e.g., `%2F..`) and query parameters to be extracted and directly interpolated into internal GitHub API requests (`https://api.github.com/repos/{repo}`).
 **Learning:** Using overly permissive capture groups (like `[^/]+`) for URL parsing allows attackers to include malicious characters that can alter the structure of downstream network requests.
 **Prevention:** Always use strict character classes (e.g., `[A-Za-z0-9\-]+/[A-Za-z0-9\-_.]+`) when extracting and validating repository names or similar identifiers from URLs to prevent injection and traversal vulnerabilities.
+
+## 2024-06-25 - [HIGH] Fix Markdown injection / formatting breakage
+**Vulnerability:** The functions `filter_command` and `recap_command` in `functions/telegram_bot.py` placed user-provided and unescaped article titles directly into Markdown links when generating responses. This allowed unescaped characters like `[` and `]` to break Telegram Markdown V1 formatting, potentially causing display issues or errors in rendering the response.
+**Learning:** Dynamically generated text elements (such as titles from scraped or user-saved articles) that are injected into Markdown templates can break the rendering engine if they contain markdown syntax characters.
+**Prevention:** Always sanitize dynamically generated text using formatting-safe escapes (like `escape_markdown_v1`) before interpolating it into a string that will be sent via an API requiring `parse_mode='Markdown'`.

--- a/functions/telegram_bot.py
+++ b/functions/telegram_bot.py
@@ -1283,16 +1283,17 @@ async def filter_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     cat_label = t(f'cat_{category}', user_lang)
     message = t('filter_results', user_lang, category=cat_label, count=len(articles))
     
-    from .security_utils import sanitize_markdown_url, stable_hash
+    from .security_utils import sanitize_markdown_url, stable_hash, escape_markdown_v1
     keyboard = []
     for i, article in enumerate(articles, 1):
         title = article.get('title', 'Untitled')[:50]
+        safe_title = escape_markdown_v1(title)
         raw_url = article.get('url', '')
         url = sanitize_markdown_url(raw_url)
         if url.startswith('http'):
-            message += f"{i}. [{title}]({url})\n"
+            message += f"{i}. [{safe_title}]({url})\n"
         else:
-            message += f"{i}. {title}\n"
+            message += f"{i}. {safe_title}\n"
 
         # Create read and summarize buttons for each item
         if url.startswith('http'):
@@ -1373,7 +1374,7 @@ async def recap_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     message = t('recap_header', user_lang)
     
     # Show top 5 recent articles
-    from .security_utils import sanitize_markdown_url, stable_hash
+    from .security_utils import sanitize_markdown_url, stable_hash, escape_markdown_v1
     from telegram import InlineKeyboardButton, InlineKeyboardMarkup
     keyboard = []
 
@@ -1382,14 +1383,15 @@ async def recap_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     for i, article in enumerate(weekly_articles[:5], 1):
         title = article.get('title', 'Untitled')[:50]
+        safe_title = escape_markdown_v1(title)
         url = sanitize_markdown_url(article.get('url', ''))
         category = article.get('category', 'tech')
         emoji = cat_emoji.get(category, '🔧')
 
         if url.startswith('http'):
-            message += f"{i}. {emoji} [{title}]({url})\n"
+            message += f"{i}. {emoji} [{safe_title}]({url})\n"
         else:
-            message += f"{i}. {emoji} {title}\n"
+            message += f"{i}. {emoji} {safe_title}\n"
 
         if url.startswith('http'):
             url_hash = stable_hash(article.get('url', ''))[:8]


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unescaped user-controlled text (titles of saved articles/links) was being directly interpolated into markdown templates in `filter_command` and `recap_command` within `functions/telegram_bot.py`. This leads to Telegram Markdown V1 parse errors if the text contains characters like `[` or `]`, which can cause a denial of service (rendering failure) for the functionality for that specific user.
🎯 **Impact:** Prevents the user from seeing their saved articles or recaps due to API errors when the bot attempts to send the incorrectly formatted markdown.
🔧 **Fix:** Applied `escape_markdown_v1` from `functions.security_utils` to the title variable before rendering it into the Markdown templates.
✅ **Verification:** Verified by running existing test suite `python -m pytest test*.py` locally. Tested markdown generation logic.

Also updated the `.jules/sentinel.md` journal with this critical learning.

---
*PR created automatically by Jules for task [2987626790847552601](https://jules.google.com/task/2987626790847552601) started by @AminSS99*